### PR TITLE
Support project as a generator option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,19 +23,19 @@ jobs:
 
     steps:
       # Setup steps
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
       - name: Install npm
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: npm install
+        run: npm ci
 
   build:
     needs: [setup]
@@ -49,18 +49,18 @@ jobs:
         node-version: [19.1.0]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
       - name: Build
-        run: npx nx run-many --all --target=build --parallel --maxParallel=10
+        run: npm run build
 
   lint:
     needs: [setup]
@@ -74,18 +74,18 @@ jobs:
         node-version: [19.1.0]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
       - name: Lint Affected Apps
-        run: npx nx run-many --all --target=lint --parallel --maxParallel=10
+        run: npm run lint
 
   test:
     needs: [setup]
@@ -99,17 +99,17 @@ jobs:
         node-version: [19.1.0]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-      - run: npx nx run-many --all --target=test --parallel --maxParallel=10
+      - run: npm run test
 
   # e2e might be too much work todo for every push, lets see.
   e2e:
@@ -124,13 +124,13 @@ jobs:
         node-version: [19.1.0]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache node modules
         id: cache-node-modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "nx serve",
     "build": "nx run nx-firebase:build",
     "test": "nx run nx-firebase:test",
+    "lint": "nx run nx-firebase:lint",
     "e2e": "nx run nx-firebase-e2e:e2e"
   },
   "private": true,
@@ -43,4 +44,3 @@
     "tslib": "^2.3.0"
   }
 }
-

--- a/packages/nx-firebase/src/generators/application/application.spec.ts
+++ b/packages/nx-firebase/src/generators/application/application.spec.ts
@@ -9,6 +9,7 @@ import {
   getEmulateTarget,
   getServeTarget,
 } from './lib'
+import { NormalizedOptions } from './schema'
 
 describe('application generator', () => {
   let tree: Tree
@@ -80,14 +81,55 @@ describe('application generator', () => {
 
     // validate the custom targets for nx-firebase apps
     const firebaseConfigName = `firebase.json`
+    const options: NormalizedOptions = {
+      name: appName,
+      projectRoot: project.root,
+      projectName: project.name,
+      firebaseConfigName,
+    }
+
     expect(project.targets.build).toEqual(getBuildTarget(project))
-    expect(project.targets.deploy).toEqual(getDeployTarget(firebaseConfigName))
+    expect(project.targets.deploy).toEqual(getDeployTarget(options))
     expect(project.targets.getconfig).toEqual(
-      getConfigTarget(project.root, firebaseConfigName),
+      getConfigTarget(project.root, options),
     )
-    expect(project.targets.emulate).toEqual(
-      getEmulateTarget(firebaseConfigName),
+    expect(project.targets.emulate).toEqual(getEmulateTarget(options))
+    expect(project.targets.serve).toEqual(getServeTarget(project))
+
+    // assume @nrwl/node is working, we dont need to validate these objects
+    expect(project.targets.lint).toBeDefined()
+    expect(project.targets.test).toBeDefined()
+  })
+
+  it('should update project configuration with --project', async () => {
+    await applicationGenerator(tree, { name: appName, project: 'fb-proj' })
+
+    const project = devkit.readProjectConfiguration(tree, appName)
+
+    //const workspaceJson = devkit.readJson(tree, '/workspace.json');
+    expect(project.root).toEqual(
+      devkit.joinPathFragments(
+        devkit.getWorkspaceLayout(tree).appsDir,
+        appName,
+      ),
     )
+
+    // validate the custom targets for nx-firebase apps
+    const firebaseConfigName = `firebase.json`
+    const options: NormalizedOptions = {
+      name: appName,
+      projectRoot: project.root,
+      projectName: project.name,
+      firebaseConfigName,
+      project: 'fb-proj',
+    }
+
+    expect(project.targets.build).toEqual(getBuildTarget(project))
+    expect(project.targets.deploy).toEqual(getDeployTarget(options))
+    expect(project.targets.getconfig).toEqual(
+      getConfigTarget(project.root, options),
+    )
+    expect(project.targets.emulate).toEqual(getEmulateTarget(options))
     expect(project.targets.serve).toEqual(getServeTarget(project))
 
     // assume @nrwl/node is working, we dont need to validate these objects

--- a/packages/nx-firebase/src/generators/application/schema.d.ts
+++ b/packages/nx-firebase/src/generators/application/schema.d.ts
@@ -2,6 +2,7 @@ import { Linter } from '@nrwl/linter'
 import { UnitTestRunner } from '../../utils/test-runners'
 
 export interface ApplicationGeneratorOptions {
+  // standard @nrwl/node:app options
   name: string
   directory?: string
   frontendProject?: string
@@ -12,6 +13,8 @@ export interface ApplicationGeneratorOptions {
   tags?: string
   unitTestRunner?: UnitTestRunner
   setParserOptionsProject?: boolean
+  // extra options for @simondotm/nx-firebase:app generator
+  project?: string
 }
 
 interface NormalizedOptions extends ApplicationGeneratorOptions {

--- a/packages/nx-firebase/src/generators/application/schema.json
+++ b/packages/nx-firebase/src/generators/application/schema.json
@@ -61,7 +61,7 @@
     "project": {
       "type": "string",
       "description": "The firebase project that should be associated with this application",
-      "default": false
+      "default": ""
     }
   },
   "additionalProperties": false,

--- a/packages/nx-firebase/src/generators/application/schema.json
+++ b/packages/nx-firebase/src/generators/application/schema.json
@@ -1,64 +1,69 @@
 {
-    "$schema": "http://json-schema.org/schema",
-    "$id": "NxFirebaseApplicationGenerator",
-    "title": "Nx Firebase Application Options Schema",
-    "description": "Nx Firebase Application Options Schema.",
-    "cli": "nx",
-    "type": "object",
-    "properties": {
-      "name": {
-        "description": "The name of the firebase application.",
-        "type": "string",
-        "$default": {
-          "$source": "argv",
-          "index": 0
-        },
-        "x-prompt": "What name would you like to use for the firebase node application?"
+  "$schema": "http://json-schema.org/schema",
+  "$id": "NxFirebaseApplicationGenerator",
+  "title": "Nx Firebase Application Options Schema",
+  "description": "Nx Firebase Application Options Schema.",
+  "cli": "nx",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "The name of the firebase application.",
+      "type": "string",
+      "$default": {
+        "$source": "argv",
+        "index": 0
       },
-      "directory": {
-        "description": "The directory of the new application.",
-        "type": "string"
-      },
-      "skipFormat": {
-        "description": "Skip formatting files.",
-        "type": "boolean",
-        "default": false
-      },
-      "skipPackageJson": {
-        "description": "Do not add dependencies to `package.json`.",
-        "type": "boolean",
-        "default": false
-      },
-      "linter": {
-        "description": "The tool to use for running lint checks.",
-        "type": "string",
-        "enum": ["eslint", "none"],
-        "default": "eslint"
-      },
-      "unitTestRunner": {
-        "description": "Test runner to use for unit tests.",
-        "type": "string",
-        "enum": ["jest", "none"],
-        "default": "jest"
-      },
-      "tags": {
-        "description": "Add tags to the application (used for linting).",
-        "type": "string"
-      },
-      "frontendProject": {
-        "description": "Frontend project that needs to access this application. This sets up proxy configuration.",
-        "type": "string"
-      },
-      "standaloneConfig": {
-        "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
-        "type": "boolean"
-      },
-      "setParserOptionsProject": {
-        "type": "boolean",
-        "description": "Whether or not to configure the ESLint `parserOptions.project` option. We do not do this by default for lint performance reasons.",
-        "default": false
-      }
+      "x-prompt": "What name would you like to use for the firebase node application?"
     },
-    "additionalProperties": false,
-    "required": ["name"]
-  }
+    "directory": {
+      "description": "The directory of the new application.",
+      "type": "string"
+    },
+    "skipFormat": {
+      "description": "Skip formatting files.",
+      "type": "boolean",
+      "default": false
+    },
+    "skipPackageJson": {
+      "description": "Do not add dependencies to `package.json`.",
+      "type": "boolean",
+      "default": false
+    },
+    "linter": {
+      "description": "The tool to use for running lint checks.",
+      "type": "string",
+      "enum": ["eslint", "none"],
+      "default": "eslint"
+    },
+    "unitTestRunner": {
+      "description": "Test runner to use for unit tests.",
+      "type": "string",
+      "enum": ["jest", "none"],
+      "default": "jest"
+    },
+    "tags": {
+      "description": "Add tags to the application (used for linting).",
+      "type": "string"
+    },
+    "frontendProject": {
+      "description": "Frontend project that needs to access this application. This sets up proxy configuration.",
+      "type": "string"
+    },
+    "standaloneConfig": {
+      "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
+      "type": "boolean"
+    },
+    "setParserOptionsProject": {
+      "type": "boolean",
+      "description": "Whether or not to configure the ESLint `parserOptions.project` option. We do not do this by default for lint performance reasons.",
+      "default": false
+    },
+    "project": {
+      "type": "string",
+      "description": "The firebase project that should be associated with this application",
+      "default": false
+    }
+  },
+  "additionalProperties": false,
+  "required": ["name"]
+}


### PR DESCRIPTION
New firebase applications can now be generated with `--project` option eg.
`nx g @simondotm/nx-firebase:app <projectName> --project <firebaseProjectAlias>`

This will be added to `deploy`, `serve`, `getconfig` and `emulate` targets, to enable a firebase project alias (defined in `.firebaserc`) to be explicitly selected for a firebase application target. 