### PR TITLE
Preparation for codebase support

### DIFF
--- a/packages/nx-firebase/src/generators/application/files_firebase/firebase.json__tmpl__
+++ b/packages/nx-firebase/src/generators/application/files_firebase/firebase.json__tmpl__
@@ -23,16 +23,14 @@
   "storage": {
       "rules": "<%= root %>/storage.rules"
   },
-  "functions": [
-    {
-      "codebase": "<%= name %>",
-      "predeploy": [
-        "npx nx build <%= name %>"
-      ],
-      "runtime": "<%= firebaseNodeRuntime %>",      
-      "source": "dist/<%= root %>"
-    }
-  ],
+  "functions": {
+    "codebase": "<%= name %>",
+    "predeploy": [
+      "npx nx build <%= name %>"
+    ],
+    "runtime": "<%= firebaseNodeRuntime %>",      
+    "source": "dist/<%= root %>"
+  },
   "emulators": {
     "auth": {
       "port": 9099

--- a/packages/nx-firebase/src/generators/application/files_firebase/firebase.json__tmpl__
+++ b/packages/nx-firebase/src/generators/application/files_firebase/firebase.json__tmpl__
@@ -27,8 +27,7 @@
     {
       "codebase": "<%= name %>",
       "predeploy": [
-        "npx nx build <%= name %>",
-        "npx nx lint <%= name %>"
+        "npx nx build <%= name %>"
       ],
       "runtime": "<%= firebaseNodeRuntime %>",      
       "source": "dist/<%= root %>"

--- a/packages/nx-firebase/src/generators/application/files_workspace/firebase.__name__.json__tmpl__
+++ b/packages/nx-firebase/src/generators/application/files_workspace/firebase.__name__.json__tmpl__
@@ -27,8 +27,7 @@
     {
       "codebase": "<%= name %>",
       "predeploy": [
-        "npx nx build <%= name %>",
-        "npx nx lint <%= name %>"
+        "npx nx build <%= name %>"
       ],
       "runtime": "<%= firebaseNodeRuntime %>",
       "source": "dist/<%= root %>"

--- a/packages/nx-firebase/src/generators/application/files_workspace/firebase.__name__.json__tmpl__
+++ b/packages/nx-firebase/src/generators/application/files_workspace/firebase.__name__.json__tmpl__
@@ -23,16 +23,14 @@
   "storage": {
       "rules": "<%= root %>/storage.rules"
   },
-  "functions": [
-    {
-      "codebase": "<%= name %>",
-      "predeploy": [
-        "npx nx build <%= name %>"
-      ],
-      "runtime": "<%= firebaseNodeRuntime %>",
-      "source": "dist/<%= root %>"
-    }
-  ],
+  "functions": {
+    "codebase": "<%= name %>",
+    "predeploy": [
+      "npx nx build <%= name %>"
+    ],
+    "runtime": "<%= firebaseNodeRuntime %>",
+    "source": "dist/<%= root %>"
+  },
   "emulators": {
     "auth": {
       "port": 9099


### PR DESCRIPTION
For new firebase applications created with `nx g @simondotm/nx-firebase:app`:
* `functions` field is no longer an array, since that might not be compatible with some users firebase-tools version
* However we can add `codebase` field to functions object in preparation
* We can also add the `runtime` field
* Removed lint from the deploy, seems unnecessary