### PR TITLE
Only install firebase dependencies as needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Additionally:
 - [Firebase Emulators](docs/nx-firebase-emulators.md)
 - [Firebase Databases](docs/nx-firebase-databases.md)
 - [Firebase Projects](docs/nx-firebase-projects.md)
+- [Firebase Versions](docs/firebase-versions.md)
 
 **Nx Libraries**
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Additionally:
 # User Guide
 
 - **[Quick Start](docs/quick-start.md)**
+- [Nx-Firebase Applications](docs/nx-firebase-applications.md)
 
 **Nx Firebase**
 
-- [Firebase Applications](docs/nx-firebase-applications.md)
 - [Firebase Functions](docs/nx-firebase-functions.md)
 - [Firebase Hosting](docs/nx-firebase-hosting.md)
 - [Firebase Emulators](docs/nx-firebase-emulators.md)

--- a/docs/firebase-versions.md
+++ b/docs/firebase-versions.md
@@ -7,9 +7,10 @@
     - [Node 14 support](#node-14-support)
     - [Node 12 support](#node-12-support)
   - [ES Modules Support](#es-modules-support)
-  - [Firebase Functions Versions](#firebase-functions-versions)
   - [Firebase Admin SDK Versions](#firebase-admin-sdk-versions)
-  - [V2 Cloud Functions](#v2-cloud-functions)
+  - [Firebase Functions Versions](#firebase-functions-versions)
+    - [V2 Cloud Functions](#v2-cloud-functions)
+  - [Firebase Client SDK](#firebase-client-sdk)
   - [Nx-Firebase Plugin Defaults](#nx-firebase-plugin-defaults)
 
 ## Firebase Node Versions
@@ -17,42 +18,43 @@
 ### Node 18 support
 
 - Currently in preview only for firebase functions
-- Use [lastest version](https://github.com/firebase/firebase-tools/releases) of `firebase-tools`
+- The latest Node 18 version is `18.12.1`
+- Use functions runtime `nodejs18`
+- `firebase-tools` - use [lastest version](https://github.com/firebase/firebase-tools/releases)
+- `firebase-functions` - [latest version](https://github.com/firebase/firebase-functions/releases)
+- `firebase-admin` - [latest version](https://github.com/firebase/firebase-functions/releases)
 
 ### Node 16 support
 
 - Node 16 is the currently [recommended runtime](https://cloud.google.com/functions/docs/concepts/nodejs-runtime) for firebase functions
-- Supported as default from [version 10.0.0](https://github.com/firebase/firebase-tools/releases/tag/v10.0.0) of `firebase-tools`
 - The latest Node 16 version is `16.19.0`
 - Use functions runtime `nodejs16`
-- Recommend minimum [version 10](https://github.com/firebase/firebase-tools/releases/tag/v10.9.2) of `firebase-tools` for Node 16
+- `firebase-tools` supports Node 16 as default from [version 10.0.0](https://github.com/firebase/firebase-tools/releases/tag/v10.0.0), recommend minimum [version 10.9.2](https://github.com/firebase/firebase-tools/releases/tag/v10.9.2)
+- `firebase-functions` - [latest version](https://github.com/firebase/firebase-functions/releases)
+- `firebase-admin` - [latest version](https://github.com/firebase/firebase-functions/releases)
 
 ### Node 14 support
 
 - The latest Node 14 version is `14.21.2`
-- Recommend minimum [version 9](https://github.com/firebase/firebase-tools/releases/tag/v9.23.3) of `firebase-tools` for Node 14
 - Use functions runtime `nodejs14`
+- `firebase-tools` - minimum [version 9.23.3](https://github.com/firebase/firebase-tools/releases/tag/v9.23.3)
+- `firebase-functions` - [latest version](https://github.com/firebase/firebase-functions/releases)
+- `firebase-admin` - [latest version](https://github.com/firebase/firebase-functions/releases)
 - Node 14 introduces ESM support (see below)
 
 ### Node 12 support
 
 - Node 12 support was dropped in [version 11.0.0](https://github.com/firebase/firebase-tools/releases/tag/v11.0.0) of the firebase tools.
-- Use [version 9](https://github.com/firebase/firebase-tools/releases/tag/v9.23.3) or [version 10](https://github.com/firebase/firebase-tools/releases/tag/v10.9.2) of `firebase-tools` if you require Node 12, but note that it is now deprecated.
-- `firebase-functions` supported upto [version 3](https://github.com/firebase/firebase-functions/releases/tag/v3.24.1)
-- `firebase-admin` upto [version 9]()
+- Use functions runtime `nodejs12`
+- `firebase-tools` supports Node 12 until [version 10.9.2](https://github.com/firebase/firebase-tools/releases/tag/v10.9.2), but note that it is now deprecated.
+- `firebase-functions` supports Node 12 upto [version 3.24.1](https://github.com/firebase/firebase-functions/releases/tag/v3.24.1)
+- `firebase-admin` supports Node 12 upto [version 10.3.0](https://github.com/firebase/firebase-admin-node/releases/tag/v10.3.0)
 
 ## ES Modules Support
 
 - [ES Modules are supported](https://cloud.google.com/functions/docs/concepts/nodejs-runtime#using_es_modules) in Node 14+ runtimes
 - Recommend minimum `firebase-functions` minimum [version 9.16.2+](https://github.com/firebase/firebase-tools/releases/tag/v9.16.2) (which has `@google-cloud/functions-framework@1.9.0`)
 - At least [version 9](https://github.com/firebase/firebase-tools/releases/tag/v9.23.3) of `firebase-tools` is necessary, but later versions likely to provide better support
-
-## Firebase Functions Versions
-
-- [Latest Github Release](https://github.com/firebase/firebase-functions/releases)
-- [Version 4.0.0+](https://github.com/firebase/firebase-functions/releases/tag/v4.0.0) of `firebase-functions`
-  - drops support for Node 8, 10, 12
-  - drops support for `firebase-admin` versions 8 and 9
 
 ## Firebase Admin SDK Versions
 
@@ -68,7 +70,14 @@
   - Supports ES Modules
 - [All Release Notes](https://firebase.google.com/support/release-notes/admin/node)
 
-## V2 Cloud Functions
+## Firebase Functions Versions
+
+- [Latest Github Release](https://github.com/firebase/firebase-functions/releases)
+- [Version 4.0.0+](https://github.com/firebase/firebase-functions/releases/tag/v4.0.0) of `firebase-functions`
+  - drops support for Node 8, 10, 12
+  - drops support for `firebase-admin` versions 8 and 9
+
+### V2 Cloud Functions
 
 A [2nd generation of cloud functions](https://firebase.google.com/docs/functions/beta) became [generally available](https://cloud.google.com/blog/products/serverless/cloud-functions-2nd-generation-now-generally-available) in August 2022 with main differences for v2 functions:
 
@@ -83,6 +92,10 @@ The [2nd generation of firebase functions](https://firebase.google.com/docs/func
 
 Using v2 functions requires `import * as functionsV2 from "firebase-functions/v2"`
 
+## Firebase Client SDK
+
+The `nx-firebase` plugin executors focus only on backend deployment and function compilation, so Firebase client SDK version considerations only apply to frontend applications, which doesn't tend to require as much dependency management, unless you are using a client application library such as [Angular/AngularFire](https://github.com/angular/angularfire#angular-and-firebase-versions).
+
 ## Nx-Firebase Plugin Defaults
 
 `nx-firebase` plugin does not require or enforce any particular versions of firebase packages/cli.
@@ -92,5 +105,6 @@ That said, typically only certain combinations of Nx/Firebase/Node versions make
 New applications generated in new Nx workspaces by `@simondotm/nx-firebase` will install:
 
 - Functions with `nodejs16` runtime enabled
-- `firebase-tools` version 11
-- `firebase-functions` version 4
+- `firebase-tools` version 11.x
+- `firebase-functions` version 4.x
+- `firebase-admin` version 11.x

--- a/docs/firebase-versions.md
+++ b/docs/firebase-versions.md
@@ -1,0 +1,96 @@
+# Firebase Versions
+
+- [Firebase Versions](#firebase-versions)
+  - [Firebase Node Versions](#firebase-node-versions)
+    - [Node 18 support](#node-18-support)
+    - [Node 16 support](#node-16-support)
+    - [Node 14 support](#node-14-support)
+    - [Node 12 support](#node-12-support)
+  - [ES Modules Support](#es-modules-support)
+  - [Firebase Functions Versions](#firebase-functions-versions)
+  - [Firebase Admin SDK Versions](#firebase-admin-sdk-versions)
+  - [V2 Cloud Functions](#v2-cloud-functions)
+  - [Nx-Firebase Plugin Defaults](#nx-firebase-plugin-defaults)
+
+## Firebase Node Versions
+
+### Node 18 support
+
+- Currently in preview only for firebase functions
+- Use [lastest version](https://github.com/firebase/firebase-tools/releases) of `firebase-tools`
+
+### Node 16 support
+
+- Node 16 is the currently [recommended runtime](https://cloud.google.com/functions/docs/concepts/nodejs-runtime) for firebase functions
+- Supported as default from [version 10.0.0](https://github.com/firebase/firebase-tools/releases/tag/v10.0.0) of `firebase-tools`
+- The latest Node 16 version is `16.19.0`
+- Use functions runtime `nodejs16`
+- Recommend minimum [version 10](https://github.com/firebase/firebase-tools/releases/tag/v10.9.2) of `firebase-tools` for Node 16
+
+### Node 14 support
+
+- The latest Node 14 version is `14.21.2`
+- Recommend minimum [version 9](https://github.com/firebase/firebase-tools/releases/tag/v9.23.3) of `firebase-tools` for Node 14
+- Use functions runtime `nodejs14`
+- Node 14 introduces ESM support (see below)
+
+### Node 12 support
+
+- Node 12 support was dropped in [version 11.0.0](https://github.com/firebase/firebase-tools/releases/tag/v11.0.0) of the firebase tools.
+- Use [version 9](https://github.com/firebase/firebase-tools/releases/tag/v9.23.3) or [version 10](https://github.com/firebase/firebase-tools/releases/tag/v10.9.2) of `firebase-tools` if you require Node 12, but note that it is now deprecated.
+- `firebase-functions` supported upto [version 3](https://github.com/firebase/firebase-functions/releases/tag/v3.24.1)
+- `firebase-admin` upto [version 9]()
+
+## ES Modules Support
+
+- [ES Modules are supported](https://cloud.google.com/functions/docs/concepts/nodejs-runtime#using_es_modules) in Node 14+ runtimes
+- Recommend minimum `firebase-functions` minimum [version 9.16.2+](https://github.com/firebase/firebase-tools/releases/tag/v9.16.2) (which has `@google-cloud/functions-framework@1.9.0`)
+- At least [version 9](https://github.com/firebase/firebase-tools/releases/tag/v9.23.3) of `firebase-tools` is necessary, but later versions likely to provide better support
+
+## Firebase Functions Versions
+
+- [Latest Github Release](https://github.com/firebase/firebase-functions/releases)
+- [Version 4.0.0+](https://github.com/firebase/firebase-functions/releases/tag/v4.0.0) of `firebase-functions`
+  - drops support for Node 8, 10, 12
+  - drops support for `firebase-admin` versions 8 and 9
+
+## Firebase Admin SDK Versions
+
+- [Latest Github Release](https://github.com/firebase/firebase-admin-node/releases)
+- [Version 11.2.0+](https://firebase.google.com/support/release-notes/admin/node#cloud-firestore_2)
+  - Adds support for `@google-cloud/firestore` v6.4.0 to support `COUNT` queries
+- [Version 11.0.0+](https://firebase.google.com/support/release-notes/admin/node#version_1100_-_16_june_2022)
+  - Drops support for Node 12
+  - Upgrades `@google-cloud/firestore` to v5 which may contain breaking changes
+  - Upgrades `@google-cloud/storage` to v6 which may contain breaking changes
+- [Version 10.0.0+](https://firebase.google.com/support/release-notes/admin/node#version_1000_-_14_october_2021)
+  - Drops support for Node 10
+  - Supports ES Modules
+- [All Release Notes](https://firebase.google.com/support/release-notes/admin/node)
+
+## V2 Cloud Functions
+
+A [2nd generation of cloud functions](https://firebase.google.com/docs/functions/beta) became [generally available](https://cloud.google.com/blog/products/serverless/cloud-functions-2nd-generation-now-generally-available) in August 2022 with main differences for v2 functions:
+
+- Concurrency for function instances
+- Now uses Cloud Run for improved efficiency
+- New trigger types
+- Improved cold-starts, minimum instances etc.
+
+See also [Cloud Functions version comparison](https://cloud.google.com/functions/docs/concepts/version-comparison).
+
+The [2nd generation of firebase functions](https://firebase.google.com/docs/functions/beta) is currently in beta preview and it's unclear at this time when that will end.
+
+Using v2 functions requires `import * as functionsV2 from "firebase-functions/v2"`
+
+## Nx-Firebase Plugin Defaults
+
+`nx-firebase` plugin does not require or enforce any particular versions of firebase packages/cli.
+
+That said, typically only certain combinations of Nx/Firebase/Node versions make sense and it can be tricky to get versions aligned depending on which workspace configurations are required for a project.
+
+New applications generated in new Nx workspaces by `@simondotm/nx-firebase` will install:
+
+- Functions with `nodejs16` runtime enabled
+- `firebase-tools` version 11
+- `firebase-functions` version 4

--- a/docs/firebase-versions.md
+++ b/docs/firebase-versions.md
@@ -6,6 +6,7 @@
     - [Node 16 support](#node-16-support)
     - [Node 14 support](#node-14-support)
     - [Node 12 support](#node-12-support)
+    - [Node 10](#node-10)
   - [ES Modules Support](#es-modules-support)
   - [Firebase Admin SDK Versions](#firebase-admin-sdk-versions)
   - [Firebase Functions Versions](#firebase-functions-versions)
@@ -49,6 +50,10 @@
 - `firebase-tools` supports Node 12 until [version 10.9.2](https://github.com/firebase/firebase-tools/releases/tag/v10.9.2), but note that it is now deprecated.
 - `firebase-functions` supports Node 12 upto [version 3.24.1](https://github.com/firebase/firebase-functions/releases/tag/v3.24.1)
 - `firebase-admin` supports Node 12 upto [version 10.3.0](https://github.com/firebase/firebase-admin-node/releases/tag/v10.3.0)
+
+### Node 10
+
+Node 10 is no longer supported by firebase or `nx-firebase`.
 
 ## ES Modules Support
 

--- a/docs/nx-firebase-applications.md
+++ b/docs/nx-firebase-applications.md
@@ -8,7 +8,7 @@ When a new Nx Firebase application project is added to the workspace it will gen
 
 **Within the application folder:**
 
-- A buildable Typescript node library for Firebase functions
+- Default `src` Typescript source code for Firebase functions
 - Default `package.json` for the Firebase functions
 - Default `firestore.indexes` for Firestore database indexes
 - Default `firestore.rules` for Firestore database rules
@@ -24,7 +24,7 @@ When a new Nx Firebase application project is added to the workspace it will gen
 
 - A default/empty `.firebaserc` in the root of the workspace (if it doesn't already exist)
 
-You should use `firebase --add` to register your projects & aliases in the `.firebaserc`.
+You should use `npx firebase --add` to register your [projects & aliases](nx-firebase-projects.md) in the `.firebaserc`.
 
 ## Nx-Firebase Application Targets (Executors)
 

--- a/docs/nx-firebase-functions.md
+++ b/docs/nx-firebase-functions.md
@@ -1,6 +1,22 @@
 # Firebase Functions
 
-An Nx-Firebase app is essentially a Firebase _functions_ directory (along with the few other configuration files as mentioned above). The main difference is that there isn't a directory called `functions` which you may be used to from projects setup by the Firebase CLI; with Nx-Firebase your app directory IS your functions folder.
+- [Firebase Functions](#firebase-functions)
+  - [Nx-Firebase Applications Overview](#nx-firebase-applications-overview)
+  - [Nx-Firebase Application Files](#nx-firebase-application-files)
+  - [Nx-Firebase Application Naming](#nx-firebase-application-naming)
+  - [Node Environments / Runtimes for Firebase Functions](#node-environments--runtimes-for-firebase-functions)
+  - [Typescript Configurations for Firebase Functions](#typescript-configurations-for-firebase-functions)
+  - [ES Modules](#es-modules)
+
+## Nx-Firebase Applications Overview
+
+An Nx-Firebase app is essentially a Firebase _functions_ directory (along with the few other configuration files as mentioned above).
+
+The main difference is that there isn't a directory called `functions` which you may be used to from projects setup by the Firebase CLI; with Nx-Firebase your app directory IS your functions folder.
+
+See the [quickstart guide for functions](quick-start.md#create-firebase-application) for how to generate a functions application.
+
+## Nx-Firebase Application Files
 
 Inside the new `apps/appname` directory you will find the following functions-specific files:
 
@@ -8,19 +24,19 @@ Inside the new `apps/appname` directory you will find the following functions-sp
 - `src` - Your Firebase functions code goes in here. You are free to structure your code however you like in this directory
 - `tsconfig.json` and `tsconfig.app.json` as usual
 
-> **Note:** _Firebase functions `tsconfig.app.json` is by default set to target `es2018` which is the maximum ES version for Node 10 engine. This override exists in case the root `tsconfig.base.json` sets an ES target that is incompatible with Firebase Functions Node environment. If you are using Node 12 engine, you can change this target to `es2019`._
-
 ## Nx-Firebase Application Naming
 
-You may find it convenient/familiar to create your Nx-Firebase application simply with `functions` as it's app name eg. `nx g @simondotm/nx-firebase:app functions`.
+You may find it convenient/familiar to create your Nx-Firebase application simply with `functions` as it's app name eg.:
+
+- `nx g @simondotm/nx-firebase:app functions`.
 
 If you have multiple Firebase projects in your workspace, the Nx-Firebase application generator supports the `--directory` option, so you may also find it convenient to organise your workspace as follows:
 
-`apps/<projectname>/...<projectapps>`
+- `apps/<projectname>/...<projectapps>`
 
 And generate your app as follows:
 
-`nx g @simondotm/nx-firebase:app functions --directory projectname`
+- `nx g @simondotm/nx-firebase:app functions --directory projectname`
 
 So your workspace layout might look like this:
 
@@ -38,3 +54,49 @@ So your workspace layout might look like this:
         /web
         ...
 ```
+
+## Node Environments / Runtimes for Firebase Functions
+
+Firebase Functions are deployed by the Firebase CLI to specific Nodejs runtime environments.
+
+The required runtime must be set, and can be specified in two places:
+
+In the `functions/package.json` as a number (eg. `14`, `16`, `18` etc.):
+
+```
+  "engines": {
+    "node": "16"
+  },
+```
+
+Or per function, in the `firebase.json` configuration as a definition (eg. `nodejs14`, `nodejs16`, `nodejs18` etc.):
+
+```
+  "functions": {
+    "runtime": "nodejs16",
+    ...
+  },
+```
+
+The runtimes should ideally be the same for all functions in a project.
+
+## Typescript Configurations for Firebase Functions
+
+Depending on [your selected node runtime](https://stackoverflow.com/questions/59787574/typescript-tsconfig-settings-for-node-js-12/59787575#59787575), your Typescript `tsconfig.json` files for functions applications and libraries should set an appropriate ES version, eg.:
+
+```
+{
+  "compilerOptions": {
+    ...
+    "target": "es2021"
+  }
+}
+```
+
+> **Note:** _Firebase functions `tsconfig.app.json` is by default set to target `es2021` which is the maximum ES version for Node 16 runtime engine. This override exists in case the root `tsconfig.base.json` sets an ES target that is incompatible with Firebase Functions Node environment. If you are using a different Node engine, you can change this target manually._
+
+See [here](firebase-versions.md#firebase-node-versions) for more information about firebase node versions.
+
+## ES Modules
+
+See [here](firebase-versions.md#es-modules-support) for more information about firebase support for ES modules with functions.

--- a/docs/nx-firebase-projects.md
+++ b/docs/nx-firebase-projects.md
@@ -7,12 +7,13 @@
   - [Updating Firebase Configurations](#updating-firebase-configurations)
   - [Binding Nx projects to Firebase projects](#binding-nx-projects-to-firebase-projects)
   - [Renaming Projects](#renaming-projects)
+  - [Deployment Environments](#deployment-environments)
 
 ## Introduction
 
 Firebase projects are created in the firebase web console, and then specified in your local workspace configurations as deployment targets in your `.firebaserc` file, along with a `firebase.json` configuration for the various cloud components of that project (databases/functions/sites etc.).
 
-`nx-firebase` generally maps one `@simondotm/nx-firebase:app` to one firebase project.
+`nx-firebase` generally assumes a mapping of one `@simondotm/nx-firebase:app` to one firebase project and configuration file.
 
 ## Nx Workspaces With Single Firebase Projects
 
@@ -45,3 +46,31 @@ You can ensure this is always the case for commands like `nx deploy app` etc. by
 ## Renaming Projects
 
 **Important:** _If you do rename your firebase configuration files, remember to update (or remove) any `--config` settings in your Nx-Firebase application's `serve` and `deploy` targets in your `workspace.json` or `angular.json` configuration file._
+
+## Deployment Environments
+
+A common practice with Firebase is to generate different Firebase projects for each deployment environments (such as dev / staging / production etc.)
+
+This can be manually achieved with `nx-firebase` by adding `production` targets to your Nx `project.json` files eg.:
+
+```
+    "deploy": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "npx firebase deploy --config firebase.json --project your-dev-firebase-project"
+      },
+      "configurations": {
+        "production": {
+          "command": "npx firebase deploy --config firebase.json --project your-prod-firebase-project"
+        }
+      }
+    },
+
+```
+
+You can now run:
+
+- `nx deploy my-firebase-app` for dev deployment
+- `nx deploy my-firebase-app --prod` for production deployment
+
+Note that `your-dev-firebase-project` and `your-prod-firebase-project` must exist as [aliases](https://firebase.google.com/docs/cli#project_aliases) in your `.firebaserc` file for this to work.

--- a/docs/nx-versions.md
+++ b/docs/nx-versions.md
@@ -4,8 +4,6 @@ Nx versions change rapidly, and are often linked to Angular releases.
 
 The `nx-firebase` plugin does not currently have a migration script, so recommended changes for updating from older Nx versions are as follows:
 
-- From Nx version 12.5.9+,
-- Upgrade Node version to at least 14.2.0
 - Nx versions prior to 13.10.0 used `@nrwl/tao` dependency which doesn't seem to get migrated automatically, so...
 - If you are using Nx version < 13.10.x, we would recommend that Nx updates are applied sequentially to ensure safe migrations using this sequence of commands for each update:
   - `npx nx @nrwl/workspace@<version>`
@@ -16,25 +14,30 @@ The `nx-firebase` plugin does not currently have a migration script, so recommen
 
 Then, run this sequence for each minor release upto Nx 13.10.x, where the list of each minor Nx Update release `version` is:
 
-- `12.2.0` (use same `@nrwl/tao` version unless specified otherwise)
-- `12.3.6`
-- `12.4.0`,
-- `12.5.9` - recommend running `nx g @nrwl/workspace:convert-to-nx-project --all` for this version
-- `12.6.6`
-- `12.7.2`
-- `12.8.0`
-- `12.9.0` and `12.10.0` seem to be problematic, so can skip to:
-- `13.0.0`
-- `13.0.2` - at this point you will need to `npm install @simondotm/nx-firebase@0.3.4`
-- `13.1.6` (use tao version `@13.1.4`)
-- `13.2.3` (use tao version `@13.2.4`)
-- `13.3.12`
-- `13.4.6`
-- `13.5.3`
-- `13.6.1`
-- `13.7.3`
-- `13.8.8` - In this release `@nrwl/node:package` is replaced with `@nrwl/js:tsc`
-- `13.9.7` - In this release `@nrwl/tao` is replaced with the `nx` cli, so manual updates of `@nrwl/tao` package version are no longer necessary from hereon
-- `13.10.6` - The last minor release of Nx 13.
+| Nx Version | `@nrwl/tao` Version | Notes                                                                                                                                           |
+| ---------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `12.2.0`   | Same                | (use same `@nrwl/tao` version unless specified otherwise)                                                                                       |
+| `12.3.6`   | Same                |                                                                                                                                                 |
+| `12.4.0`   | Same                |                                                                                                                                                 |
+| `12.5.9`   | Same                | recommend running `nx g @nrwl/workspace:convert-to-nx-project --all` for this version                                                           |
+|            |                     | Upgrade node to at least 14.2.0 from this version                                                                                               |
+| `12.6.6`   | Same                |                                                                                                                                                 |
+| `12.7.2`   | Same                |                                                                                                                                                 |
+| `12.8.0`   | Same                |                                                                                                                                                 |
+| `12.9.0`   | Same                | and `12.10.0` seem to be problematic, so can skip to:                                                                                           |
+| `13.0.0`   | Same                |                                                                                                                                                 |
+| `13.0.2`   | Same                | at this point you will need to `npm install @simondotm/nx-firebase@0.3.4`                                                                       |
+| `13.1.6`   | `@13.1.4`           |                                                                                                                                                 |
+| `13.2.3`   | `@13.2.4`           |                                                                                                                                                 |
+| `13.3.12`  | Same                |                                                                                                                                                 |
+| `13.4.6`   | Same                |                                                                                                                                                 |
+| `13.5.3`   | Same                |                                                                                                                                                 |
+| `13.6.1`   | Same                |                                                                                                                                                 |
+| `13.7.3`   | Same                |                                                                                                                                                 |
+| `13.8.8`   | Same                | In this release `@nrwl/node:package` is replaced with `@nrwl/js:tsc`                                                                            |
+| `13.9.7`   | n/a                 | In this release `@nrwl/tao` is replaced with the `nx` cli, so manual updates of `@nrwl/tao` package version are no longer necessary from hereon |
+| `13.10.6`  | n/a                 | The last minor release of Nx 13.                                                                                                                |
 
 The plugin is not yet tested with Nx version 14+
+
+See also [Firebase Versions](firebase-versions.md).

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,6 +1,16 @@
 # Quick Start
 
+- [Quick Start](#quick-start)
+  - [Installation](#installation)
+  - [Create Firebase Application](#create-firebase-application)
+  - [Build Project](#build-project)
+  - [Deploy Project (Firebase functions)](#deploy-project-firebase-functions)
+  - [Serve Project](#serve-project)
+  - [Get Remote Functions Config](#get-remote-functions-config)
+
 ## Installation
+
+Assuming you have
 
 **`npm install @simondotm/nx-firebase`**
 

--- a/packages/nx-firebase/src/generators/application/application.spec.ts
+++ b/packages/nx-firebase/src/generators/application/application.spec.ts
@@ -58,7 +58,7 @@ describe('application generator', () => {
       `apps/${appDirectory}/tsconfig.app.json`,
     )
     expect(tsConfig.compilerOptions.emitDecoratorMetadata).toBe(true)
-    expect(tsConfig.compilerOptions.target).toBe('es2015')
+    expect(tsConfig.compilerOptions.target).toBe('es2021') // default target is node 16
     expect(tsConfig.exclude).toEqual([
       'jest.config.ts',
       'src/**/*.spec.ts',

--- a/packages/nx-firebase/src/generators/application/lib/create-files.ts
+++ b/packages/nx-firebase/src/generators/application/lib/create-files.ts
@@ -81,7 +81,8 @@ export function createFiles(tree: Tree, options: NormalizedOptions): void {
       '',
       substitutions,
     )
-  } else {
-    logger.log('✓ .firebaserc already exists in this workspace')
   }
+  // else {
+  //   logger.log('✓ .firebaserc already exists in this workspace')
+  // }
 }

--- a/packages/nx-firebase/src/generators/application/lib/update-tsconfig.ts
+++ b/packages/nx-firebase/src/generators/application/lib/update-tsconfig.ts
@@ -1,9 +1,10 @@
 import type { Tree } from '@nrwl/devkit'
 import { joinPathFragments, updateJson } from '@nrwl/devkit'
+import { tsConfigTarget } from '../../../utils'
 import type { NormalizedOptions } from '../schema'
 
 /**
- * With firebase cli > 10.0.1 now compatible with node versions >=13 we can use es modules rather than commonjs
+ * With firebase cli > 10.0.1 now compatible with node versions >=14 we can use es modules rather than commonjs
  *
  * @param tree
  * @param options
@@ -14,7 +15,7 @@ export function updateTsConfig(tree: Tree, options: NormalizedOptions): void {
     joinPathFragments(options.projectRoot, 'tsconfig.app.json'),
     (json) => {
       json.compilerOptions.emitDecoratorMetadata = true
-      json.compilerOptions.target = 'es2015'
+      json.compilerOptions.target = tsConfigTarget
       return json
     },
   )

--- a/packages/nx-firebase/src/generators/init/lib/add-dependencies.ts
+++ b/packages/nx-firebase/src/generators/init/lib/add-dependencies.ts
@@ -1,4 +1,10 @@
-import type { GeneratorCallback, Tree } from '@nrwl/devkit'
+import {
+  GeneratorCallback,
+  logger,
+  readJson,
+  readRootPackageJson,
+  Tree,
+} from '@nrwl/devkit'
 import { addDependenciesToPackageJson } from '@nrwl/devkit'
 import {
   tsLibVersion,
@@ -7,21 +13,47 @@ import {
   firebaseFunctionsVersion,
   firebaseToolsVersion,
   firebaseFunctionsTestVersion,
+  killportVersion,
 } from '../../../utils/versions'
 
 export function addDependencies(tree: Tree): GeneratorCallback {
-  return addDependenciesToPackageJson(
-    tree,
-    {
-      firebase: firebaseVersion,
-      'firebase-admin': firebaseAdminVersion,
-      'firebase-functions': firebaseFunctionsVersion,
-      tslib: tsLibVersion,
-    },
-    {
-      'firebase-tools': firebaseToolsVersion,
-      'firebase-functions-test': firebaseFunctionsTestVersion,
-      'kill-port': 'latest',
-    },
+  const dependencies: Record<string, string> = {}
+  const devDependencies: Record<string, string> = {}
+
+  // SM: only add firebase related dependencies if they do not already exist
+  // This is atypical for Nx plugins that usually migrate versions automatically
+  //  however the nx-firebase plugin is not (currently) opinionated about which version is needed,
+  //  so this ensures workspaces retain control over their firebase versions.
+  const packageJson = readJson(tree, 'package.json') //readRootPackageJson()
+
+  function addDependencyIfNotPresent(
+    packageName: string,
+    packageVersion: string,
+  ) {
+    if (!packageJson.dependencies[packageName]) {
+      dependencies[packageName] = packageVersion
+    }
+  }
+  function addDevDependencyIfNotPresent(
+    packageName: string,
+    packageVersion: string,
+  ) {
+    if (!packageJson.devDependencies[packageName]) {
+      devDependencies[packageName] = packageVersion
+    }
+  }
+
+  addDependencyIfNotPresent('firebase', firebaseVersion)
+  addDependencyIfNotPresent('firebase-admin', firebaseAdminVersion)
+  addDependencyIfNotPresent('firebase-functions', firebaseFunctionsVersion)
+  addDependencyIfNotPresent('tslib', tsLibVersion)
+
+  addDevDependencyIfNotPresent('firebase-tools', firebaseToolsVersion)
+  addDevDependencyIfNotPresent(
+    'firebase-functions-test',
+    firebaseFunctionsTestVersion,
   )
+  addDevDependencyIfNotPresent('kill-port', killportVersion)
+
+  return addDependenciesToPackageJson(tree, dependencies, devDependencies)
 }

--- a/packages/nx-firebase/src/utils/versions.ts
+++ b/packages/nx-firebase/src/utils/versions.ts
@@ -1,11 +1,17 @@
-export const nxVersion = '^15.2.1'
+export const nxVersion = '^15.3.0'
 export const tsLibVersion = '^2.3.0'
 
+// Firebase packages are not managed by the plugin
+// but they are added if they do not exist already in the workspace
 export const firebaseAdminVersion = '^11.3.0'
 export const firebaseFunctionsVersion = '^4.1.0'
 export const firebaseToolsVersion = '^11.16.1'
 export const firebaseVersion = '^9.14.0'
 export const firebaseFunctionsTestVersion = '^0.2.0'
 
+// Target node 16 for all firebase projects now
 export const firebaseNodeEngine = '16'
 export const firebaseNodeRuntime = 'nodejs16'
+
+// kill-port is used by the emulator/serve target
+export const killportVersion = '2.0.1'

--- a/packages/nx-firebase/src/utils/versions.ts
+++ b/packages/nx-firebase/src/utils/versions.ts
@@ -11,7 +11,22 @@ export const firebaseFunctionsTestVersion = '^0.2.0'
 
 // Target node 16 for all firebase projects now
 export const firebaseNodeEngine = '16'
-export const firebaseNodeRuntime = 'nodejs16'
+export const firebaseNodeRuntime = `nodejs${firebaseNodeEngine}`
+
+// https://stackoverflow.com/questions/59787574/typescript-tsconfig-settings-for-node-js-12
+
+const nodeVersion: Record<string, string> = {
+  '12': 'es2019',
+  '14': 'es2020',
+  '16': 'es2021',
+  '18': 'es2022',
+}
+
+export const tsConfigTarget = nodeVersion[firebaseNodeEngine]
+
+if (!tsConfigTarget) {
+  throw new Error('Undefined tsConfigTarget')
+}
 
 // kill-port is used by the emulator/serve target
 export const killportVersion = '2.0.1'


### PR DESCRIPTION
* Updated docs
* `init` generator will only install firebase packages if they do not already exist in the workspace `package.json`
* `tsconfig` now targets correct es version for node environment