### PR TITLE
fix: remove entry point from template `package.json`

### DIFF
--- a/packages/nx-firebase/src/generators/application/files/package.json__tmpl__
+++ b/packages/nx-firebase/src/generators/application/files/package.json__tmpl__
@@ -13,7 +13,6 @@
   "engines": {
     "node": " <%= firebaseNodeEngine %>"
   },
-  "main": "src/index.js",
   "dependencies": {
   },
   "devDependencies": {


### PR DESCRIPTION
Executors automatically write the main entry point to `package.json` so it should not be in the template package file.
This is necessary since use of `@nrwl/node:webpack` executor for bundling builds has a different entry point (`./main.js`) to `@nrwl/js:tsc` (`src/index.js`).