### PR TITLE
fix: generator targets

### DIFF
--- a/packages/nx-firebase/src/generators/application/application.spec.ts
+++ b/packages/nx-firebase/src/generators/application/application.spec.ts
@@ -87,10 +87,13 @@ describe('application generator', () => {
 
     // validate the custom targets for nx-firebase apps
     const firebaseConfigName = `firebase.json`
+    // const projectName = project.name //NX14/15 project.json format only has project name in file
+    const projectName = appName
+
     const options: NormalizedOptions = {
       name: appName,
       projectRoot: project.root,
-      projectName: project.name,
+      projectName,
       firebaseConfigName,
     }
 
@@ -99,8 +102,8 @@ describe('application generator', () => {
     expect(project.targets.getconfig).toEqual(
       getConfigTarget(project.root, options),
     )
-    expect(project.targets.emulate).toEqual(getEmulateTarget(options))
-    expect(project.targets.serve).toEqual(getServeTarget(project))
+    expect(project.targets.emulate).toEqual(getEmulateTarget(options, project))
+    expect(project.targets.serve).toEqual(getServeTarget(options))
 
     // assume @nrwl/node is working, we dont need to validate these objects
     expect(project.targets.lint).toBeDefined()
@@ -122,10 +125,12 @@ describe('application generator', () => {
 
     // validate the custom targets for nx-firebase apps
     const firebaseConfigName = `firebase.json`
+    // const projectName = project.name //NX14/15 project.json format only has project name in file
+    const projectName = appName
     const options: NormalizedOptions = {
       name: appName,
       projectRoot: project.root,
-      projectName: project.name,
+      projectName,
       firebaseConfigName,
       project: 'fb-proj',
     }
@@ -135,8 +140,8 @@ describe('application generator', () => {
     expect(project.targets.getconfig).toEqual(
       getConfigTarget(project.root, options),
     )
-    expect(project.targets.emulate).toEqual(getEmulateTarget(options))
-    expect(project.targets.serve).toEqual(getServeTarget(project))
+    expect(project.targets.emulate).toEqual(getEmulateTarget(options, project))
+    expect(project.targets.serve).toEqual(getServeTarget(options))
 
     // assume @nrwl/node is working, we dont need to validate these objects
     expect(project.targets.lint).toBeDefined()

--- a/packages/nx-firebase/src/generators/application/lib/add-project.ts
+++ b/packages/nx-firebase/src/generators/application/lib/add-project.ts
@@ -61,12 +61,22 @@ export function getConfigTarget(
   }
 }
 
-export function getEmulateTarget(options: NormalizedOptions) {
+export function getEmulateTarget(
+  options: NormalizedOptions,
+  project: ProjectConfiguration,
+) {
   return {
     executor: 'nx:run-commands',
     options: {
       commands: [
-        `npx kill-port --port 9099,5001,8080,9000,5000,8085,9199,9299`,
+        `node -e 'setTimeout(()=>{},5000)'`,
+        `kill-port --port 9099,5001,8080,9000,5000,8085,9199,9299,4000,4400,4500`,
+        `firebase functions:config:get ${getFirebaseConfig(
+          options,
+        )}${getFirebaseProject(options)} > ${joinPathFragments(
+          'dist',
+          project.root,
+        )}/.runtimeconfig.json`,
         `firebase emulators:start ${getFirebaseConfig(
           options,
         )}${getFirebaseProject(options)}`,
@@ -76,13 +86,13 @@ export function getEmulateTarget(options: NormalizedOptions) {
   }
 }
 
-export function getServeTarget(project: ProjectConfiguration) {
+export function getServeTarget(options: NormalizedOptions) {
   return {
     executor: 'nx:run-commands',
     options: {
       commands: [
-        `nx run ${project.name}:build --watch`,
-        `nx run ${project.name}:emulate`,
+        `nx run ${options.projectName}:build --watch`,
+        `nx run ${options.projectName}:emulate`,
       ],
     },
   }
@@ -94,8 +104,8 @@ export function addProject(tree: Tree, options: NormalizedOptions): void {
   project.targets.build = getBuildTarget(project)
   project.targets.deploy = getDeployTarget(options)
   project.targets.getconfig = getConfigTarget(project.root, options)
-  project.targets.emulate = getEmulateTarget(options)
-  project.targets.serve = getServeTarget(project)
+  project.targets.emulate = getEmulateTarget(options, project)
+  project.targets.serve = getServeTarget(options)
 
   updateProjectConfiguration(tree, options.projectName, project)
 }


### PR DESCRIPTION
* No need for `npx` in executor commands
* Extra ports killed when starting emulator
* Get the firebase config directly to `dist` folder when running `serve` to ensure emulator starts up
