### PR TITLE
fix: remove redundant assets from functions build executor

### DIFF
--- a/e2e/nx-firebase-e2e/tests/nx-firebase.spec.ts
+++ b/e2e/nx-firebase-e2e/tests/nx-firebase.spec.ts
@@ -250,7 +250,7 @@ describe('nx-firebase e2e', () => {
       expect(() =>
         checkFilesExist(
           `${distDir}/package.json`,
-          `${distDir}/readme.md`,
+          // `${distDir}/readme.md`, // we no longer copy .md files as a default asset
           `${distDir}/src/index.js`,
         ),
       ).not.toThrow()

--- a/packages/nx-firebase/src/generators/application/lib/add-project.ts
+++ b/packages/nx-firebase/src/generators/application/lib/add-project.ts
@@ -28,9 +28,11 @@ export function getBuildTarget(project: ProjectConfiguration) {
       main: joinPathFragments(project.sourceRoot, 'index.ts'),
       tsConfig: joinPathFragments(project.root, 'tsconfig.app.json'),
       packageJson: joinPathFragments(project.root, 'package.json'),
+      // no need to copy these assets anymore.
+      // .runtimeconfig.json cant be copied at build time because it is .gitignored and Nx also ignores it.
       assets: [
-        joinPathFragments(project.root, '*.md'),
-        joinPathFragments(project.root, '.runtimeconfig.json'),
+        // joinPathFragments(project.root, '*.md'),
+        // joinPathFragments(project.root, '.runtimeconfig.json'),
       ],
     },
   }


### PR DESCRIPTION
 Previously the nx-firebase app generator added files to the `assets[]` array for the build executor.
We don't need to copy these.
We also had the `.runtimeconfig.json` listed, but this is redundant because this file is in the `.gitignore` list and Nx will not copy assets that are `.gitignored`.
