### PR TITLE
fix: Use `@nrwl/workspace:run-commands` while based on Nx 13.10.6+

### DIFF
--- a/packages/nx-firebase/src/generators/application/lib/add-project.ts
+++ b/packages/nx-firebase/src/generators/application/lib/add-project.ts
@@ -40,7 +40,7 @@ export function getBuildTarget(project: ProjectConfiguration) {
 
 export function getDeployTarget(options: NormalizedOptions) {
   return {
-    executor: 'nx:run-commands',
+    executor: '@nrwl/workspace:run-commands',
     options: {
       command: `firebase deploy${getFirebaseConfig(
         options,
@@ -54,7 +54,7 @@ export function getConfigTarget(
   options: NormalizedOptions,
 ) {
   return {
-    executor: 'nx:run-commands',
+    executor: '@nrwl/workspace:run-commands',
     options: {
       command: `firebase functions:config:get${getFirebaseConfig(
         options,
@@ -68,7 +68,7 @@ export function getEmulateTarget(
   project: ProjectConfiguration,
 ) {
   return {
-    executor: 'nx:run-commands',
+    executor: '@nrwl/workspace:run-commands',
     options: {
       commands: [
         `node -e 'setTimeout(()=>{},5000)'`,
@@ -90,7 +90,7 @@ export function getEmulateTarget(
 
 export function getServeTarget(options: NormalizedOptions) {
   return {
-    executor: 'nx:run-commands',
+    executor: '@nrwl/workspace:run-commands',
     options: {
       commands: [
         `nx run ${options.projectName}:build --watch`,


### PR DESCRIPTION
Since the plugin version is targetting Nx 13.10.6 minimum workspace, we need to use `@nrwl/workspace:run-commands` rather than `nx:run-commands` in the generator.

Linked to https://github.com/simondotm/nx-firebase/issues/94.