### PR TITLE
feat: support `nx:run-commands` in compatible hosts

### DIFF
--- a/packages/nx-firebase/src/generators/application/lib/add-project.ts
+++ b/packages/nx-firebase/src/generators/application/lib/add-project.ts
@@ -6,6 +6,17 @@ import {
 import { workspaceNxVersion } from '../../../utils'
 import type { NormalizedOptions } from '../schema'
 
+/**
+ * Return run-commands executor that is most compatible with host workspace version
+ */
+function getRunCommandsExecutor() {
+  // `nx:run-commands` executor is supported from Nx 14.8.0+
+  const supportsNxRunCommands = workspaceNxVersion.versionCode >= 140800
+  return supportsNxRunCommands
+    ? 'nx:run-commands'
+    : '@nrwl/workspace:run-commands'
+}
+
 function getFirebaseProject(options: NormalizedOptions) {
   if (options.project) {
     return ` --project ${options.project}`
@@ -41,7 +52,7 @@ export function getBuildTarget(project: ProjectConfiguration) {
 
 export function getDeployTarget(options: NormalizedOptions) {
   return {
-    executor: '@nrwl/workspace:run-commands',
+    executor: getRunCommandsExecutor(),
     options: {
       command: `firebase deploy${getFirebaseConfig(
         options,
@@ -55,7 +66,7 @@ export function getConfigTarget(
   options: NormalizedOptions,
 ) {
   return {
-    executor: '@nrwl/workspace:run-commands',
+    executor: getRunCommandsExecutor(),
     options: {
       command: `firebase functions:config:get${getFirebaseConfig(
         options,
@@ -69,7 +80,7 @@ export function getEmulateTarget(
   project: ProjectConfiguration,
 ) {
   return {
-    executor: '@nrwl/workspace:run-commands',
+    executor: getRunCommandsExecutor(),
     options: {
       commands: [
         `node -e 'setTimeout(()=>{},5000)'`,
@@ -109,7 +120,7 @@ export function getServeTarget(options: NormalizedOptions) {
       ]
 
   return {
-    executor: '@nrwl/workspace:run-commands',
+    executor: getRunCommandsExecutor(),
     options: {
       commands,
     },

--- a/packages/nx-firebase/src/utils/workspace.ts
+++ b/packages/nx-firebase/src/utils/workspace.ts
@@ -14,6 +14,7 @@ type PackageJson = {
 export type WorkspaceVersion =
   | {
       version: string
+      versionCode: number // major*10000 + minor*100 + patch eg. 151001
       major: number
       minor: number
     }
@@ -30,10 +31,14 @@ function readNxWorkspaceVersion(): WorkspaceVersion {
     const workspaceNxVersion = workspaceNxPackageVersion.match(semVerRegEx)
     if (workspaceNxVersion.length) {
       const semver = workspaceNxVersion[0].split('.')
+      const major = parseInt(semver[0])
+      const minor = parseInt(semver[1])
+      const patch = parseInt(semver[2])
       return {
         version: workspaceNxVersion[0],
-        major: parseInt(semver[0]),
-        minor: parseInt(semver[1]),
+        versionCode: major * 10000 + minor * 100 + patch,
+        major,
+        minor,
       }
     }
   }


### PR DESCRIPTION
If the host workspace is Nx version 14.8.0+, the app generator can use `nx:run-commands` as the executor for command targets.

Workspaces updating to 14.8.0 will automatically get this change by the [Nx migration script](https://github.com/nrwl/nx/blob/14.8.x/packages/workspace/src/migrations/update-14-8-0/change-run-commands-executor.ts).

Linked to #94 