### PR TITLE
fix: emulator target setTimeout not working

### DIFF
--- a/docs/nx-firebase-targets.md
+++ b/docs/nx-firebase-targets.md
@@ -73,7 +73,7 @@ Starts the firebase emulator:
   "executor": "nx:run-commands",
   "options": {
     "commands": [
-      "node -e 'setTimeout(()=>{},5000)'",
+      "node -e \"setTimeout(()=>{},5000)\"",
       "kill-port --port 9099,5001,8080,9000,5000,8085,9199,9299,4000,4400,4500",
       "firebase functions:config:get --config firebase.functions.json --project my-project > dist/functions/.runtimeconfig.json",
       "firebase emulators:start  --config firebase.json"
@@ -90,7 +90,7 @@ Starts the firebase emulator:
   "executor": "@nrwl/workspace:run-commands",
   "options": {
     "commands": [
-      "node -e 'setTimeout(()=>{},5000)'",
+      "node -e \"setTimeout(()=>{},5000)\"",
       "kill-port --port 9099,5001,8080,9000,5000,8085,9199,9299,4000,4400,4500",
       "firebase functions:config:get --config firebase.functions.json --project my-project > dist/functions/.runtimeconfig.json",
       "firebase emulators:start  --config firebase.json"

--- a/packages/nx-firebase/src/generators/application/lib/add-project.ts
+++ b/packages/nx-firebase/src/generators/application/lib/add-project.ts
@@ -83,7 +83,7 @@ export function getEmulateTarget(
     executor: getRunCommandsExecutor(),
     options: {
       commands: [
-        `node -e 'setTimeout(()=>{},5000)'`,
+        `node -e \"setTimeout(()=>{},5000)\"`,
         `kill-port --port 9099,5001,8080,9000,5000,8085,9199,9299,4000,4400,4500`,
         `firebase functions:config:get ${getFirebaseConfig(
           options,


### PR DESCRIPTION
On Windows (and possibly other platforms), the `setTimeout` before calling `kill-port` is not working as expected.

### **Problem**
- The delay is not adhered to, and the `kill-port` runs immediately
- An empty file with the name `{}` is written to disk in the root of the workspace

![image](https://user-images.githubusercontent.com/656884/225733754-92eda027-d18a-4967-ade8-a55353b727e5.png)

### **Solution**

- Modify and escape the code passed to `node -e` to fix the above-mentioned problems