### PR TITLE
Sort functions by codebase

### DIFF
--- a/packages/nx-firebase/src/generators/function/function.spec.ts
+++ b/packages/nx-firebase/src/generators/function/function.spec.ts
@@ -252,8 +252,8 @@ describe('function generator', () => {
         // console.log(firebaseConfig)
 
         // expect(firebaseConfig.functions.length).toEqual(2)
-        expect(firebaseConfig.functions[0]).toEqual(testFunction)
-        expect(firebaseConfig.functions[1]).toEqual({
+        expect(firebaseConfig.functions).toContainEqual(testFunction)
+        expect(firebaseConfig.functions).toContainEqual({
           codebase: 'my-firebase-function',
           source: 'dist/apps/my-firebase-function',
           runtime: `nodejs16`,

--- a/packages/nx-firebase/src/generators/function/lib/add-function.ts
+++ b/packages/nx-firebase/src/generators/function/lib/add-function.ts
@@ -19,6 +19,10 @@ export function addFunction(tree: Tree, options: NormalizedOptions) {
       }
     }
     json.functions.push(functionConfig)
+    // sort the codebases to be neat & tidy
+    json.functions.sort((a: FirebaseFunction, b: FirebaseFunction) => {
+      return a.codebase < b.codebase ? -1 : a.codebase > b.codebase ? 1 : 0
+    })
     return json
   })
 }

--- a/packages/nx-firebase/src/generators/sync/sync.ts
+++ b/packages/nx-firebase/src/generators/sync/sync.ts
@@ -218,6 +218,9 @@ export async function syncGenerator(
     })
     if (configUpdated) {
       config.functions = updatedFunctions
+      config.functions.sort((a: FirebaseFunction, b: FirebaseFunction) => {
+        return a.codebase < b.codebase ? -1 : a.codebase > b.codebase ? 1 : 0
+      })
       writeJson(tree, configFileName, config)
     }
   })


### PR DESCRIPTION
It's handy to have functions in sorted order in the firebase.json config.
This PR sorts them when added, or renamed.
