### PR TITLE
Add `serve` executor

### DIFF
--- a/docs/nx-firebase-emulators.md
+++ b/docs/nx-firebase-emulators.md
@@ -11,11 +11,36 @@ This will launch the Firebase emulators using the app's firebase configuration
 It will also build all functions attached to this app in watch mode, so that any changes you make to your function code will be automatically be rebuilt and reloaded by the emulator.
 
 
+## Nx Issue with Firebase Emulator
+
 Due to a bug in Nx, which does not correctly pass process termination signals to child processes, CTRL+C after `serve` does not shutdown the emulator properly.
 
 For this reason, `serve` uses the `kill-port` npm package to ensure the emulator is properly shutdown before re-running `serve`.
 
-Unfortunately this means the emulator will not properly export data on exit either. This can be worked around using an `npm` script as described [here](https://github.com/simondotm/nx-firebase/issues/40).
+Unfortunately this means the emulator will not properly export data on exit either. 
+
+
+The Nx issue is discussed [here](https://github.com/simondotm/nx-firebase/issues/40).
 
 Hopefully Nx will address this issue in future releases.
+
+
+## Emulator workaround
+
+Until Nx fix this problem, this can be worked around using an experimental executor in the plugin as follows:
+
+
+Change the `serve` target in your Firebase app `project.json` from:
+
+* `nx:run-commands` to
+* `@simondotm/nx-firebase:serve`
+
+This executor handles CTRL+C in a way that ensures the Firebase Emulator shuts down cleanly.
+
+With this executor you can pass extra CLI parameters for example:
+
+* `nx serve myfirebaseapp --only functions` - only serve functions in the Emulator
+
+
+
 

--- a/packages/nx-firebase/executors.json
+++ b/packages/nx-firebase/executors.json
@@ -1,2 +1,10 @@
 {
+  "$schema": "http://json-schema.org/schema",
+  "executors": {
+    "serve": {
+      "implementation": "./src/executors/serve/serve",
+      "schema": "./src/executors/serve/schema.json",
+      "description": "firebase cli emulation serve executor"
+    }    
+  }
 }

--- a/packages/nx-firebase/src/executors/serve/schema.d.ts
+++ b/packages/nx-firebase/src/executors/serve/schema.d.ts
@@ -1,0 +1,5 @@
+// maintains the existing executor format as `nx:run-commands` for compatibility
+export interface FirebaseServeExecutorSchema {
+  commands: string[]
+  __unparsed__: string[]
+}

--- a/packages/nx-firebase/src/executors/serve/schema.json
+++ b/packages/nx-firebase/src/executors/serve/schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "title": "Firebase serve",
+  "description": "Runs the Firebase CLI emulator for the target project",
+  "type": "object",
+  "properties": {
+    "commands": {
+      "description": "The serve commands - watch & emulate.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }, 
+    "__unparsed__": {
+      "hidden": true,
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "$default": {
+        "$source": "unparsed"
+      },
+      "x-priority": "internal"
+    }           
+  },
+  "required": []
+}

--- a/packages/nx-firebase/src/executors/serve/serve.spec.ts
+++ b/packages/nx-firebase/src/executors/serve/serve.spec.ts
@@ -1,0 +1,11 @@
+// import { FirebaseServeExecutorSchema } from './schema'
+// import runFirebaseServeExecutor from './firebase'
+
+// const options: FirebaseServeExecutorSchema = {}
+
+describe('Firebase Serve Executor', () => {
+  it('can run', async () => {
+    // const output = await runFirebaseServeExecutor([])
+    // expect(output.success).toBe(true)
+  })
+})

--- a/packages/nx-firebase/src/executors/serve/serve.ts
+++ b/packages/nx-firebase/src/executors/serve/serve.ts
@@ -1,0 +1,136 @@
+import {
+  ExecutorContext,
+  logger,
+  TargetConfiguration,
+  ProjectConfiguration,
+} from '@nrwl/devkit'
+import { FirebaseServeExecutorSchema } from './schema'
+import { spawn } from 'child_process'
+
+type NxRunCommandsTargetConfiguration = TargetConfiguration<{
+  command?: string
+  commands?: string[]
+}>
+
+type ValidTarget = 'firebase' | 'watch' | 'emulate'
+
+function getCommandFromTarget(
+  project: ProjectConfiguration,
+  targetName: ValidTarget,
+  commandGrep: string,
+) {
+  const target = project.targets[targetName] as NxRunCommandsTargetConfiguration
+  if (!target) {
+    throw new Error(
+      `Could not find target '${targetName}' in project '${project.name}'`,
+    )
+  }
+  const commands: string[] = [
+    ...(target.options.command ? [target.options.command] : []),
+    ...(target.options.commands ? target.options.commands : []),
+  ].filter((cmd) => cmd.includes(commandGrep))
+
+  if (commands.length === 0) {
+    throw new Error(
+      `Could not find a command in target '${targetName}' that matches '${commandGrep}'`,
+    )
+  }
+
+  if (commands.length !== 1) {
+    logger.warn(
+      `Found multiple commands in target '${targetName}' that match '${commandGrep}', using first match`,
+    )
+  }
+  return commands[0]
+}
+
+export default async function runFirebaseServeExecutor(
+  options: FirebaseServeExecutorSchema,
+  context: ExecutorContext,
+) {
+  return new Promise<{ success: boolean }>((resolve) => {
+    const projectName = context.projectName
+    const projects = context.projectsConfigurations
+    const project = projects.projects[projectName]
+
+    // Determine the watch target command
+    const watchCommand = getCommandFromTarget(
+      project,
+      'watch',
+      'nx run-many --targets=build',
+    )
+
+    // Determine the firebase target command, so we get --config & --project
+    const firebaseCommand = getCommandFromTarget(
+      project,
+      'firebase',
+      'firebase',
+    )
+
+    // Determine the emulator target command
+    const emulateCommand = getCommandFromTarget(
+      project,
+      'emulate',
+      'emulators:',
+    ).replace(`nx run ${projectName}:firebase`, '')
+
+    // Run the watch process
+    const watchProcess = spawn(watchCommand, [], {
+      shell: true,
+      stdio: 'inherit',
+      detached: false,
+    }).on('exit', (code) => {
+      if (!code) {
+        logger.warn(`serve: watch process finished successfully`)
+      } else {
+        logger.error(`serve: watch process finished with error '${code}'`)
+      }
+    })
+
+    // determine any extra commands passed on the command line
+    const extraArgs =
+      options.__unparsed__.length > 0
+        ? ' ' + options.__unparsed__.join(' ')
+        : ''
+
+    // Run the firebase emulator process
+    const emulatorProcess = spawn(
+      `${firebaseCommand} ${emulateCommand} ${extraArgs}`,
+      [],
+      {
+        shell: true,
+        stdio: 'inherit',
+        detached: false,
+      },
+    )
+    emulatorProcess.on('exit', (code) => {
+      if (!code) {
+        logger.warn(`serve: Firebase emulator finished successfully`)
+        resolve({ success: true }) // not sure what difference this makes
+      } else {
+        logger.error(`serve: Firebase emulator finished with error '${code}'`)
+        resolve({ success: false })
+      }
+    })
+
+    // Handle signals for serve executor process
+    const processExitListener = (signal) => {
+      // logger.error(`\nserve: executor received signal '${signal}'`)
+      if (signal === 'SIGINT') {
+        logger.warn(`\nserve: terminating`)
+        // no need for these it seems
+        // emulatorProcess.kill()
+        // watchProcess.kill()
+      }
+      if (signal === 0) {
+        logger.warn(`serve: finished successfully`)
+      }
+      if (signal === 1) {
+        logger.error(`serve: finished with errors`)
+      }
+    }
+    process.on('exit', processExitListener)
+    process.on('SIGTERM', processExitListener)
+    process.on('SIGINT', processExitListener)
+  })
+}


### PR DESCRIPTION
Added a simple `serve` executor to workaround the Nx issue with `SIGINT` (#40) so that CTRL+C when serving shuts down the Firebase Emulator properly.

This executor spawns the `watch` target and `emulate` target commands directly, without using `nx:run-commands` (which is the cause of the issue)

To use the executor, make the following change to your `project.json` for your firebase app:

* change `nx:run-commands` to 
* `@simondotm/nx-firebase:serve`

The executor uses your existing project configuration to run `watch` and `serve` target commands.


> **Note: This executor is experimental and intended to be a temporary solution until Nx fixes the process exit issue.**