### PR TITLE
fix: sync generator now renames app targets

### DIFF
--- a/e2e/nx-firebase-e2e/test-utils/index.ts
+++ b/e2e/nx-firebase-e2e/test-utils/index.ts
@@ -1,6 +1,6 @@
 
 import { names } from '@nx/devkit'
-import { runNxCommandAsync } from '@nx/plugin/testing'
+import { readJson, runNxCommandAsync } from '@nx/plugin/testing'
 
 const NPM_SCOPE = '@proj'
 
@@ -203,5 +203,89 @@ export function getLibImport(projectData: ProjectData) {
 export function addImport(mainTs: string, addition: string) {
   const replaced = mainTs.replace(IMPORT_MATCH, `${IMPORT_MATCH}\n${addition}`)
   return replaced
+}
+
+export function validateProjectConfig(projectDir: string, projectName: string) {
+    const project = readJson(
+      `${projectDir}/project.json`,
+    )
+    // expect(project.root).toEqual(`apps/${projectName}`)
+    expect(project.targets).toEqual(
+      expect.objectContaining({
+        build: {
+          executor: 'nx:run-commands',
+          options: {
+            command: `echo Build succeeded.`,
+          },
+        },
+        watch: {
+          executor: 'nx:run-commands',
+          options: {
+            command: `nx run-many --targets=build --projects=tag:firebase:dep:${projectName} --parallel=100 --watch`,
+          },
+        },
+        lint: {
+          executor: 'nx:run-commands',
+          options: {
+            command: `nx run-many --targets=lint --projects=tag:firebase:dep:${projectName} --parallel=100`,
+          },
+        },
+        test: {
+          executor: 'nx:run-commands',
+          options: {
+            command: `nx run-many --targets=test --projects=tag:firebase:dep:${projectName} --parallel=100`,
+          },
+        },
+        firebase: {
+          executor: 'nx:run-commands',
+          options: {
+            command: `firebase --config=firebase.json`,
+          },
+          configurations: {
+            production: {
+              command: `firebase --config=firebase.json`,
+            },
+          },
+        },
+        killports: {
+          executor: 'nx:run-commands',
+          options: {
+            command: `kill-port --port 9099,5001,8080,9000,5000,8085,9199,9299,4000,4400,4500`,
+          },
+        },
+        getconfig: {
+          executor: 'nx:run-commands',
+          options: {
+            command: `nx run ${projectName}:firebase functions:config:get > ${projectDir}/environment/.runtimeconfig.json`,
+          },
+        },
+        emulate: {
+          executor: 'nx:run-commands',
+          options: {
+            commands: [
+              `nx run ${projectName}:killports`,
+              `nx run ${projectName}:firebase emulators:start --import=${projectDir}/.emulators --export-on-exit`,
+            ],
+            parallel: false,
+          },
+        },
+        serve: {
+          executor: 'nx:run-commands',
+          options: {
+            commands: [
+              `nx run ${projectName}:watch`,
+              `nx run ${projectName}:emulate`,
+            ],
+          },
+        },
+        deploy: {
+          executor: 'nx:run-commands',
+          dependsOn: ['build'],
+          options: {
+            command: `nx run ${projectName}:firebase deploy`,
+          },
+        },
+      }),
+    )
 }
 

--- a/e2e/nx-firebase-e2e/tests/nx-firebase.spec.ts
+++ b/e2e/nx-firebase-e2e/tests/nx-firebase.spec.ts
@@ -27,6 +27,7 @@ import {
   getLibImport,
   addImport,
   safeRunNxCommandAsync,
+  validateProjectConfig,
 } from '../test-utils'
 
 
@@ -255,6 +256,8 @@ describe('nx-firebase e2e', () => {
             ...expectedAppFiles(appData),
           ),
         ).not.toThrow()
+    
+        validateProjectConfig(appData.projectDir, appData.projectName)  
 
         // cleanup - app
         await cleanAppAsync(appData)
@@ -291,6 +294,8 @@ describe('nx-firebase e2e', () => {
 
           const project = readJson(`${appData.projectDir}/project.json`)
           expect(project.name).toEqual(`${appData.projectName}`)
+
+          validateProjectConfig(appData.projectDir, appData.projectName)  
 
           // cleanup - app
           await cleanAppAsync(appData)                
@@ -792,6 +797,7 @@ describe('nx-firebase e2e', () => {
           expectStrings(result.stdout, [
             `CHANGE Firebase app '${appData.projectName}' linked to primary config file was renamed to '${renamedAppData.projectName}', skipping rename of '${renamedAppData.configName}'`,
             `CHANGE Firebase app '${appData.projectName}' was renamed to '${renamedAppData.projectName}', updated firebase:name tag`,
+            `CHANGE Firebase app '${appData.projectName}' was renamed to '${renamedAppData.projectName}', updated targets`,
             `CHANGE Firebase app '${appData.projectName}' was renamed to '${renamedAppData.projectName}', updated firebase:dep tag in firebase function '${functionData.projectName}'`,
             `CHANGE Firebase app '${appData.projectName}' was renamed to '${renamedAppData.projectName}', updated environment assets path in firebase function '${functionData.projectName}'`,
             `CHANGE Firebase app '${appData.projectName}' was renamed to '${renamedAppData.projectName}', updated firebase:dep tag in firebase function '${functionData2.projectName}'`,
@@ -813,7 +819,10 @@ describe('nx-firebase e2e', () => {
           // check that app project has correct --config setting after rename
           expect(readJson(`${renamedAppData.projectDir}/project.json`).targets.firebase.options.command).toContain(
             `--config=${renamedAppData.configName}`
-          )                    
+          )      
+          
+          // check rename was successful
+          validateProjectConfig(renamedAppData.projectDir, renamedAppData.projectName)          
       
           // run another sync to check there should be no orphaned functions from an app rename
           const result2 = await syncGeneratorAsync()
@@ -849,6 +858,7 @@ describe('nx-firebase e2e', () => {
           expectStrings(result.stdout, [
             `CHANGE Firebase app '${appData.projectName}' linked to primary config file was renamed to '${renamedAppData.projectName}', skipping rename of '${renamedAppData.configName}'`,
             `CHANGE Firebase app '${appData.projectName}' was renamed to '${renamedAppData.projectName}', updated firebase:name tag`,
+            `CHANGE Firebase app '${appData.projectName}' was renamed to '${renamedAppData.projectName}', updated targets`,           
             `CHANGE Firebase app '${appData.projectName}' was renamed to '${renamedAppData.projectName}', updated firebase:dep tag in firebase function '${renamedFunctionData.projectName}'`,
             `CHANGE Firebase app '${appData.projectName}' was renamed to '${renamedAppData.projectName}', updated environment assets path in firebase function '${renamedFunctionData.projectName}'`,
             `CHANGE Firebase function '${functionData.projectName}' was renamed to '${renamedFunctionData.projectName}', updated firebase:name tag`,
@@ -876,7 +886,10 @@ describe('nx-firebase e2e', () => {
           expect(readJson(`${renamedFunctionData.projectDir}/project.json`).targets.deploy.options.command).toContain(
             `--only functions:${renamedFunctionData.projectName}`
           )           
-                         
+                      
+          // check rename was successful
+          validateProjectConfig(renamedAppData.projectDir, renamedAppData.projectName)          
+          
 
           // cleanup - function, then app
           await cleanFunctionAsync(renamedFunctionData)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "nx run nx-firebase:build",
     "test": "nx run nx-firebase:test",
     "lint": "nx run nx-firebase:lint",
-    "e2e": "nx run nx-firebase-e2e:e2e --silent=false",
+    "e2e": "nx run nx-firebase-e2e:e2e --silent=false --bail=true",
     "release": "cd packages/nx-firebase && npm version",
     "release-help": "echo `npm run version -- v1.2.3` to set package version & commit tag",
     "compat:test": "npm run build && nx run compat:build && node dist/e2e/compat/main.js",

--- a/packages/nx-firebase/src/generators/sync/lib/update-targets.ts
+++ b/packages/nx-firebase/src/generators/sync/lib/update-targets.ts
@@ -1,0 +1,46 @@
+import {
+  ProjectConfiguration,
+  TargetConfiguration,
+  Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit'
+
+type NxRunCommandsTargetConfiguration = TargetConfiguration<{
+  command?: string
+  commands?: string[]
+}>
+
+type ValidTarget =
+  | 'firebase'
+  | 'watch'
+  | 'emulate'
+  | 'lint'
+  | 'test'
+  | 'serve'
+  | 'deploy'
+  | 'getconfig'
+  | 'killports'
+
+export function renameCommandForTarget(
+  tree: Tree,
+  project: ProjectConfiguration,
+  targetName: ValidTarget,
+  search: string,
+  replace: string,
+) {
+  const target = project.targets[targetName] as NxRunCommandsTargetConfiguration
+  if (!target) {
+    throw new Error(
+      `Could not find target '${targetName}' in project '${project.name}'`,
+    )
+  }
+  if (target.options.commands) {
+    target.options.commands = target.options.commands.map((cmd) => {
+      return cmd.replace(search, replace)
+    })
+  }
+  if (target.options.command) {
+    target.options.command = target.options.command.replace(search, replace)
+  }
+  updateProjectConfiguration(tree, project.name, project)
+}

--- a/packages/nx-firebase/src/generators/sync/sync.ts
+++ b/packages/nx-firebase/src/generators/sync/sync.ts
@@ -21,6 +21,7 @@ import {
   updateFirebaseProjectNameTag,
   getFirebaseWorkspace,
 } from './lib'
+import { renameCommandForTarget } from './lib/update-targets'
 
 const FUNCTIONS_DEPLOY_MATCHER = /(--only[ =]functions:)([^\s]+)/
 
@@ -132,6 +133,90 @@ export async function syncGenerator(
     updateFirebaseProjectNameTag(tree, project)
     logger.info(
       `CHANGE Firebase app '${oldName}' was renamed to '${project.name}', updated firebase:name tag`,
+    )
+
+    // we also need to update nx:run-commands in the renamed projects for various targets
+
+    // test target
+    renameCommandForTarget(
+      tree,
+      project,
+      'test',
+      `tag:firebase:dep:${oldName}`,
+      `tag:firebase:dep:${project.name}`,
+    )
+    // lint target
+    renameCommandForTarget(
+      tree,
+      project,
+      'lint',
+      `tag:firebase:dep:${oldName}`,
+      `tag:firebase:dep:${project.name}`,
+    )
+    // watch target
+    renameCommandForTarget(
+      tree,
+      project,
+      'watch',
+      `tag:firebase:dep:${oldName}`,
+      `tag:firebase:dep:${project.name}`,
+    )
+    // serve target
+    renameCommandForTarget(
+      tree,
+      project,
+      'serve',
+      `${oldName}:`,
+      `${project.name}:`,
+    )
+    // deploy target
+    renameCommandForTarget(
+      tree,
+      project,
+      'deploy',
+      `${oldName}:`,
+      `${project.name}:`,
+    )
+    // getconfig target
+    renameCommandForTarget(
+      tree,
+      project,
+      'getconfig',
+      `${oldName}:`,
+      `${project.name}:`,
+    )
+    renameCommandForTarget(
+      tree,
+      project,
+      'getconfig',
+      `/${oldName}/`,
+      `/${project.name}/`,
+    )
+    // killports target
+    renameCommandForTarget(
+      tree,
+      project,
+      'killports',
+      `${oldName}:`,
+      `${project.name}:`,
+    )
+    // emulate target
+    renameCommandForTarget(
+      tree,
+      project,
+      'emulate',
+      `/${oldName}/`,
+      `/${project.name}/`,
+    )
+    renameCommandForTarget(
+      tree,
+      project,
+      'emulate',
+      `${oldName}:`,
+      `${project.name}:`,
+    )
+    logger.info(
+      `CHANGE Firebase app '${oldName}' was renamed to '${project.name}', updated targets`,
     )
   })
 


### PR DESCRIPTION
When renaming firebase app projects and running `nx g @simondotm/nx-firebase:sync`, targets on the firebase app project will also be renamed to match the new project name.

