### PR TITLE
feat: Use the custom plugin serve executor

### DIFF
--- a/docs/nx-firebase-emulators.md
+++ b/docs/nx-firebase-emulators.md
@@ -27,15 +27,19 @@ Hopefully Nx will address this issue in future releases.
 
 ## Emulator workaround
 
-Until Nx fix this problem, this can be worked around using an experimental executor in the plugin as follows:
+Until Nx fix this problem, we are using an experimental executor in the plugin as a interim workaround:
 
 
-Change the `serve` target in your Firebase app `project.json` from:
+The `serve` target in Firebase app `project.json` configurations is using:
 
-* `nx:run-commands` to
 * `@simondotm/nx-firebase:serve`
 
-This executor handles CTRL+C in a way that ensures the Firebase Emulator shuts down cleanly.
+instead of
+
+* `nx:run-commands`
+
+
+This custom executor handles CTRL+C in a way that ensures the Firebase Emulator shuts down cleanly.
 
 With this executor you can pass extra CLI parameters for example:
 

--- a/docs/nx-firebase-project-structure.md
+++ b/docs/nx-firebase-project-structure.md
@@ -92,7 +92,7 @@ We tag all dependent projects so that we can use Nx `run-many` with tag specifie
       }
     },
     "serve": {
-      "executor": "nx:run-commands",
+      "executor": "@simondotm/nx-firebase:serve",
       "options": {
         "commands": [
           "nx run your-firebase-app-project-name:watch",

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -10,7 +10,7 @@
 
 ## Install Plugin
 
-**`npm install @simondotm/nx-firebase`**
+**`npm install @simondotm/nx-firebase --save-dev`**
 
 - Installs this plugin into your Nx workspace.
 - This will also install some Nx and firebase dependencies (both for backend and frontend) to your root workspace `package.json` if they are not already installed.

--- a/e2e/nx-firebase-e2e/test-utils/index.ts
+++ b/e2e/nx-firebase-e2e/test-utils/index.ts
@@ -270,7 +270,7 @@ export function validateProjectConfig(projectDir: string, projectName: string) {
           },
         },
         serve: {
-          executor: 'nx:run-commands',
+          executor: '@simondotm/nx-firebase:serve',
           options: {
             commands: [
               `nx run ${projectName}:watch`,

--- a/packages/nx-firebase/src/generators/application/application.spec.ts
+++ b/packages/nx-firebase/src/generators/application/application.spec.ts
@@ -84,7 +84,7 @@ describe('application generator', () => {
           },
         },
         serve: {
-          executor: 'nx:run-commands',
+          executor: '@simondotm/nx-firebase:serve',
           options: {
             commands: [
               `nx run my-firebase-app:watch`,

--- a/packages/nx-firebase/src/generators/application/application.ts
+++ b/packages/nx-firebase/src/generators/application/application.ts
@@ -138,7 +138,7 @@ export async function applicationGenerator(
         },
       },
       serve: {
-        executor: 'nx:run-commands',
+        executor: '@simondotm/nx-firebase:serve',
         options: {
           commands: [
             `nx run ${options.projectName}:watch`,


### PR DESCRIPTION
Since we've made the executor for serving the emulator, we may as well use it by default until the Nx issue gets fixed. (#40)

Also updated the documentation, and added `--save-dev` to the quick start plugin install instructions (#146 )