### PR TITLE
Add sourcemaps & emulator debugging support

### DIFF
--- a/docs/nx-firebase-project-structure.md
+++ b/docs/nx-firebase-project-structure.md
@@ -86,7 +86,7 @@ We tag all dependent projects so that we can use Nx `run-many` with tag specifie
       "options": {
         "commands": [
           "nx run your-firebase-app-project-name:killports",
-          "nx run your-firebase-app-project-name:firebase emulators:start --import=apps/your-firebase-app-project-name/.emulators --export-on-exit"
+          "nx run your-firebase-app-project-name:firebase emulators:start --import=apps/your-firebase-app-project-name/.emulators --export-on-exit --inspect-functions"
         ],
         "parallel": false
       }

--- a/docs/nx-firebase-project-structure.md
+++ b/docs/nx-firebase-project-structure.md
@@ -149,6 +149,7 @@ Functions use `esbuild` to compile & bundle the code.
         "target": "node16",
         "format": ["esm"],
         "esbuildOptions": {
+          "sourcemap": true,
           "logLevel": "info"
         }
       }

--- a/e2e/nx-firebase-e2e/test-utils/index.ts
+++ b/e2e/nx-firebase-e2e/test-utils/index.ts
@@ -318,6 +318,7 @@ export function expectedFunctionProjectTargets(functionProject: ProjectData, app
         thirdParty: false,
         target: "node16",
         esbuildOptions: {
+          sourcemap: true,
           logLevel: "info"
         }
       }

--- a/e2e/nx-firebase-e2e/test-utils/index.ts
+++ b/e2e/nx-firebase-e2e/test-utils/index.ts
@@ -270,7 +270,7 @@ export function expectedAppProjectTargets(appProject: ProjectData) {
       options: {
         commands: [
           `nx run ${appProject.projectName}:killports`,
-          `nx run ${appProject.projectName}:firebase emulators:start --import=${appProject.projectDir}/.emulators --export-on-exit`,
+          `nx run ${appProject.projectName}:firebase emulators:start --import=${appProject.projectDir}/.emulators --export-on-exit --inspect-functions`,
         ],
         parallel: false,
       },

--- a/packages/nx-firebase/src/generators/application/application.spec.ts
+++ b/packages/nx-firebase/src/generators/application/application.spec.ts
@@ -78,7 +78,7 @@ describe('application generator', () => {
           options: {
             commands: [
               `nx run my-firebase-app:killports`,
-              `nx run my-firebase-app:firebase emulators:start --import=apps/my-firebase-app/.emulators --export-on-exit`,
+              `nx run my-firebase-app:firebase emulators:start --import=apps/my-firebase-app/.emulators --export-on-exit --inspect-functions`,
             ],
             parallel: false,
           },

--- a/packages/nx-firebase/src/generators/application/application.ts
+++ b/packages/nx-firebase/src/generators/application/application.ts
@@ -132,7 +132,7 @@ export async function applicationGenerator(
         options: {
           commands: [
             `nx run ${options.projectName}:killports`,
-            `nx run ${options.projectName}:firebase emulators:start --import=${options.projectRoot}/.emulators --export-on-exit`,
+            `nx run ${options.projectName}:firebase emulators:start --import=${options.projectRoot}/.emulators --export-on-exit --inspect-functions`,
           ],
           parallel: false,
         },

--- a/packages/nx-firebase/src/generators/function/function.spec.ts
+++ b/packages/nx-firebase/src/generators/function/function.spec.ts
@@ -85,6 +85,7 @@ describe('function generator', () => {
                 target: 'node16',
                 format: ['esm'],
                 esbuildOptions: {
+                  sourcemap: true,
                   logLevel: 'info',
                 },
               },

--- a/packages/nx-firebase/src/generators/function/lib/update-project.ts
+++ b/packages/nx-firebase/src/generators/function/lib/update-project.ts
@@ -30,6 +30,7 @@ export function updateProject(tree: Tree, options: NormalizedOptions): void {
       target: 'node16',
       format: [options.format || 'esm'], // default for esbuild is esm
       esbuildOptions: {
+        sourcemap: true,
         logLevel: 'info',
       },
     },


### PR DESCRIPTION
- Generate sourcemaps so the debugger can find the .ts files
- Enable --inspect-functions so

### Caveat

1. Debugger disconnects when saving files (because everything recompiles & emulators seem to restart).
2. I didn't test this yet, I just added the flags where it made sense (adding them works in a real project though)
3. I wrote no documentation for this for now