### PR TITLE
Fix runtimeconfig command

### DIFF
--- a/e2e/nx-firebase-e2e/test-utils/index.ts
+++ b/e2e/nx-firebase-e2e/test-utils/index.ts
@@ -262,7 +262,7 @@ export function expectedAppProjectTargets(appProject: ProjectData) {
     getconfig: {
       executor: 'nx:run-commands',
       options: {
-        command: `nx run ${appProject.projectName}:firebase functions:config:get > ${appProject.projectDir}/environment/.runtimeconfig.json`,
+        command: `npx firebase functions:config:get > ${appProject.projectDir}/environment/.runtimeconfig.json`,
       },
     },
     emulate: {


### PR DESCRIPTION
This solves #164.

However, I don't know how this acts when there are multiple firebase projects. I assume it breaks at that point, but I'm not sure how the original command worked, so I don't know if that's even a regression.