### PR TITLE
chore: Move @nx/node dependency to peer dependencies

### DIFF
--- a/packages/nx-firebase/package.json
+++ b/packages/nx-firebase/package.json
@@ -22,10 +22,9 @@
   "executors": "./executors.json",
   "peerDependencies": {
     "@nx/devkit": ">= 16.1.1",
+    "@nx/node": "^16.6.0",
     "@nx/workspace": ">= 16.1.1",
     "nx": ">= 16.1.1"
   },
-  "dependencies": {
-    "@nx/node": "^16.6.0"
-  }
+  "dependencies": {}
 }

--- a/packages/nx-firebase/package.json
+++ b/packages/nx-firebase/package.json
@@ -22,7 +22,6 @@
   "executors": "./executors.json",
   "peerDependencies": {
     "@nx/devkit": ">= 16.1.1",
-    "@nx/node": "^16.6.0",
     "@nx/workspace": ">= 16.1.1",
     "nx": ">= 16.1.1"
   },


### PR DESCRIPTION
By making the @nx/node dependency a peer dependency, the function generator can generate projects that better match the given Nx workspace.

Fixes #191 