### PR TITLE
chore: Update package versions manifest & dependabot interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     ignore:
       # Ignore updates to these packages:
       - dependency-name: "@nx*"
@@ -24,5 +24,6 @@ updates:
       - dependency-name: "tslib"
       - dependency-name: "typescript"
       # For all packages, ignore all patch updates
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+      # EDIT: Actually, we'll take all updates, but this is a good example
+      # - dependency-name: "*"
+      #   update-types: ["version-update:semver-patch"]

--- a/packages/nx-firebase/src/__generated__/nx-firebase-versions.ts
+++ b/packages/nx-firebase/src/__generated__/nx-firebase-versions.ts
@@ -4,8 +4,8 @@
 //------------------------------------------------------------------------------
 export const packageVersions = {
   nx: '16.8.1',
-  firebase: '9.14.0',
-  firebaseAdmin: '11.10.1',
+  firebase: '10.10.0',
+  firebaseAdmin: '11.11.1',
   firebaseFunctions: '4.8.2',
   firebaseFunctionsTest: '3.1.0',
   firebaseTools: '12.4.5',


### PR DESCRIPTION
* Dependabot updates now monthly, weekly is too often
* Run `pnpm install` to re-generate plugin package manifest