### PR TITLE
feat: Bump firebase-tools to 12.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "firebase-admin": "11.11.1",
     "firebase-functions": "4.8.2",
     "firebase-functions-test": "3.1.1",
-    "firebase-tools": "12.4.5",
+    "firebase-tools": "12.9.1",
     "jest": "29.4.3",
     "jest-environment-jsdom": "28.1.3",
     "kill-port": "2.0.1",

--- a/packages/nx-firebase/src/__generated__/nx-firebase-versions.ts
+++ b/packages/nx-firebase/src/__generated__/nx-firebase-versions.ts
@@ -8,7 +8,7 @@ export const packageVersions = {
   firebaseAdmin: '11.11.1',
   firebaseFunctions: '4.8.2',
   firebaseFunctionsTest: '3.1.1',
-  firebaseTools: '12.4.5',
+  firebaseTools: '12.9.1',
   killPort: '2.0.1',
   nodeEngine: '16',
   googleCloudFunctionsFramework: '3.3.0',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ devDependencies:
     specifier: 3.1.1
     version: 3.1.1(firebase-admin@11.11.1)(firebase-functions@4.8.2)(jest@29.4.3)
   firebase-tools:
-    specifier: 12.4.5
-    version: 12.4.5
+    specifier: 12.9.1
+    version: 12.9.1
   jest:
     specifier: 29.4.3
     version: 29.4.3(@types/node@18.7.1)(ts-node@10.9.1)
@@ -2621,6 +2621,23 @@ packages:
       - verdaccio
     dev: true
 
+  /@nrwl/js@16.8.1(@swc-node/register@1.4.2)(@swc/core@1.3.56)(@types/node@18.7.1)(nx@16.8.1)(typescript@5.1.6):
+    resolution: {integrity: sha512-I5kCtk0TUvcvJXnD6fbOI1+L4EBHbSZCXVCkv3eXKOeAj0cJ6cOt2g6S7DpWPf2P7zTq22XOPNJy3C8u9tCbgQ==}
+    dependencies:
+      '@nx/js': 16.8.1(@swc-node/register@1.4.2)(@swc/core@1.3.56)(@types/node@18.7.1)(nx@16.8.1)(typescript@5.1.6)
+    transitivePeerDependencies:
+      - '@babel/traverse'
+      - '@swc-node/register'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - debug
+      - nx
+      - supports-color
+      - typescript
+      - verdaccio
+    dev: true
+
   /@nrwl/linter@16.8.1(@swc-node/register@1.4.2)(@swc/core@1.3.56)(@types/node@18.7.1)(eslint@8.46.0)(nx@16.8.1):
     resolution: {integrity: sha512-o7DhyvNk7qXG8qdhivEd4kYw1XGqOPlXHgDBJJHeL5ASN2HWl5EBclCvKJmoci1xIJGw/9q+mJxc1/mL8Zq3dQ==}
     dependencies:
@@ -2875,7 +2892,7 @@ packages:
       '@babel/preset-env': 7.22.10(@babel/core@7.22.11)
       '@babel/preset-typescript': 7.22.11(@babel/core@7.22.11)
       '@babel/runtime': 7.22.11
-      '@nrwl/js': 16.8.1(@swc-node/register@1.4.2)(@swc/core@1.3.56)(@types/node@18.7.1)(nx@16.8.1)(typescript@4.8.4)
+      '@nrwl/js': 16.8.1(@swc-node/register@1.4.2)(@swc/core@1.3.56)(@types/node@18.7.1)(nx@16.8.1)(typescript@5.1.6)
       '@nx/devkit': 16.8.1(nx@16.8.1)
       '@nx/workspace': 16.8.1(@swc-node/register@1.4.2)(@swc/core@1.3.56)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.1.6)
@@ -6582,8 +6599,8 @@ packages:
       - supports-color
     dev: true
 
-  /firebase-tools@12.4.5:
-    resolution: {integrity: sha512-qDDJ1QgbsqQYLNGcOO34ltnqEEbyayKGMDo4Q7ScpGsISf45tYKaVlnLJSwPrIG+tMoljJ8B3s5sqeR32udfQQ==}
+  /firebase-tools@12.9.1:
+    resolution: {integrity: sha512-t/oTgGnGm3sLT3wR80B7hY6vdAs6rTlZMsmnZGsP+GeKtVzaB5KHEwLbkZuRXtqij9f35IfkQm2a4TKjKY6xUQ==}
     engines: {node: '>=16.13.0 || >=18.0.0'}
     hasBin: true
     dependencies:


### PR DESCRIPTION
Stick at Firebase CLI 12.x since 13.0+ is no longer node16.
We'll move to 13.x with the Nx 17 update