### PR TITLE
feat: Improve plugin dependency requirements

### DIFF
--- a/e2e/nx-firebase-e2e/tests/test-workspace.spec.ts
+++ b/e2e/nx-firebase-e2e/tests/test-workspace.spec.ts
@@ -43,7 +43,7 @@ describe('workspace setup', () => {
     expect(packageJson.dependencies['firebase-functions']).toBeDefined()
     expect(
       packageJson.devDependencies['firebase-functions-test'],
-    ).toBeDefined()
+    ).toBeUndefined()
 
     // check that plugin init generator adds @google-cloud/functions-framework if pnpm is being used
     // Use tmpProjPath() to detect the package manager in the e2e workspace, not the main project

--- a/packages/nx-firebase/src/__generated__/nx-firebase-versions.ts
+++ b/packages/nx-firebase/src/__generated__/nx-firebase-versions.ts
@@ -7,7 +7,6 @@ export const packageVersions = {
   firebase: '12.8.0',
   firebaseAdmin: '13.6.0',
   firebaseFunctions: '7.0.3',
-  firebaseFunctionsTest: '3.4.1',
   firebaseTools: '15.3.1',
   killPort: '2.0.1',
   nodeEngine: '20',

--- a/packages/nx-firebase/src/generators/function/function.ts
+++ b/packages/nx-firebase/src/generators/function/function.ts
@@ -9,7 +9,6 @@ import {
 } from '@nx/devkit'
 import { applicationGenerator as nodeApplicationGenerator } from '@nx/node'
 
-import { initGenerator } from '../init/init'
 import { getFirebaseConfigFromProject, updateTsConfig } from '../../utils'
 
 import { addFunctionConfig, createFiles, updateProject } from './lib'
@@ -103,10 +102,6 @@ export async function functionGenerator(
   }
 
   // const options = normalizeOptions(host, schema)
-
-  // initialise plugin
-  const initTask = await initGenerator(host, {})
-  tasks.push(initTask)
 
   // We use @nx/node:app to scaffold our function application, then modify as required
   // `nx g @nx/node:app function-name --directory functions/dir --e2eTestRunner=none --framework=none --unitTestRunner=jest --bundler=esbuild --tags=firebase:firebase-app`

--- a/packages/nx-firebase/src/generators/init/init.spec.ts
+++ b/packages/nx-firebase/src/generators/init/init.spec.ts
@@ -80,9 +80,6 @@ describe('init generator', () => {
       `^${packageVersions.firebaseFunctions}`,
     )
 
-    expect(packageJson.devDependencies['firebase-functions-test']).toBe(
-      `^${packageVersions.firebaseFunctionsTest}`,
-    )
     expect(packageJson.devDependencies['firebase-tools']).toBe(
       `^${packageVersions.firebaseTools}`,
     )
@@ -115,7 +112,6 @@ describe('init generator', () => {
 
     packageJsonDefault.devDependencies['firebase-tools'] = testVersion
     packageJsonDefault.devDependencies['kill-port'] = testVersion
-    packageJsonDefault.devDependencies['firebase-functions-test'] = testVersion
 
     devkit.writeJson(tree, 'package.json', packageJsonDefault)
 
@@ -126,9 +122,6 @@ describe('init generator', () => {
     expect(packageJson.dependencies['firebase']).toBe(testVersion)
     expect(packageJson.dependencies['firebase-admin']).toBe(testVersion)
     expect(packageJson.dependencies['firebase-functions']).toBe(testVersion)
-    expect(packageJson.devDependencies['firebase-functions-test']).toBe(
-      testVersion,
-    )
     expect(packageJson.devDependencies['firebase-tools']).toBe(testVersion)
     expect(packageJson.devDependencies['kill-port']).toBe(testVersion)
 

--- a/packages/nx-firebase/src/generators/init/lib/add-dependencies.ts
+++ b/packages/nx-firebase/src/generators/init/lib/add-dependencies.ts
@@ -74,10 +74,6 @@ export function addDependencies(tree: Tree): GeneratorCallback {
     'firebase-tools',
     `^${packageVersions.firebaseTools}`,
   )
-  addDevDependencyIfNotPresent(
-    'firebase-functions-test',
-    `^${packageVersions.firebaseFunctionsTest}`,
-  )
 
   // kill-port is used by the emulate target to ensure clean emulator startup
   // since Nx doesn't kill processes cleanly atm

--- a/packages/nx-firebase/src/generators/sync/sync.ts
+++ b/packages/nx-firebase/src/generators/sync/sync.ts
@@ -4,7 +4,6 @@ import {
   joinPathFragments,
   logger,
   readProjectConfiguration,
-  runTasksInSerial,
   Tree,
   updateProjectConfiguration,
   writeJson,
@@ -12,7 +11,6 @@ import {
 
 import { SyncGeneratorSchema } from './schema'
 import { setFirebaseConfigFromCommand } from '../../utils'
-import initGenerator from '../init/init'
 
 import {
   debugInfo,
@@ -35,13 +33,7 @@ export async function syncGenerator(
   tree: Tree,
   options: SyncGeneratorSchema,
 ): Promise<GeneratorCallback> {
-  const tasks: GeneratorCallback[] = []
-
-  // initialise plugin
-  const initTask = await initGenerator(tree, {})
-  tasks.push(initTask)
-
-  // otherwise, sync the workspace.
+  // sync the workspace.
   // build lists of firebase apps & functions that have been deleted or renamed
   debugInfo('- Syncing workspace')
 
@@ -407,7 +399,9 @@ export async function syncGenerator(
     )
   }
 
-  return runTasksInSerial(...tasks)
+  return () => {
+    // noop - no install tasks needed
+  }
 }
 
 export default syncGenerator

--- a/tools/generate-package-versions.js
+++ b/tools/generate-package-versions.js
@@ -63,7 +63,6 @@ export const packageVersions = {
   firebase: '${packageJson.devDependencies['firebase']}',
   firebaseAdmin: '${packageJson.devDependencies['firebase-admin']}',
   firebaseFunctions: '${packageJson.devDependencies['firebase-functions']}',
-  firebaseFunctionsTest: '${packageJson.devDependencies['firebase-functions-test']}',
   firebaseTools: '${packageJson.devDependencies['firebase-tools']}',
   killPort: '${packageJson.devDependencies['kill-port']}',
   nodeEngine: '${nodeVersion}',


### PR DESCRIPTION
We're running unnecessary init generator calls in function & sync generators that ensure packages exist in the workspace.
This has a side effect of adding dependencies that users may not want in their workspace.

This PR:
* Removes calls to init generator for functions + sync (on the assumption that app generator has to have previously run, and deps were added at that point)
* Removes plugin addition of `firebase-functions-test` dependency. The plugin doesn't require it, and it's optional for firebase development, so this way users are free to add it themselves if/when they need to


Fixes #269 